### PR TITLE
Create autoreduced folder in ceph if not present, also add filter for unknown RB numbers

### DIFF
--- a/job_controller/main.py
+++ b/job_controller/main.py
@@ -13,7 +13,7 @@ from job_controller.job_watcher import JobWatcher
 from job_controller.job_creator import JobCreator
 from job_controller.script_aquisition import acquire_script
 from job_controller.topic_consumer import TopicConsumer
-from job_controller.utils import create_ceph_path, logger
+from job_controller.utils import create_ceph_path, logger, ensure_ceph_path_exists
 
 
 class JobController:
@@ -73,6 +73,7 @@ class JobController:
                 reduction_id=db_reduction_id,
                 instrument=instrument_name,
             )
+            ceph_path = ensure_ceph_path_exists(ceph_path)
             job = self.job_creator.spawn_job(
                 job_name=job_name,
                 script=script,

--- a/job_controller/utils.py
+++ b/job_controller/utils.py
@@ -57,6 +57,12 @@ def load_kubernetes_config() -> None:
 
 
 def ensure_ceph_path_exists(ceph_path: str) -> str:
+    """
+    Takes a path that is intended to be on ceph and ensures that it will be correct for what we should mount and
+    apply output to.
+    :param ceph_path: Is the string path to where we should output to ceph
+    :return: The corrected path for output to ceph path
+    """
     ceph_path = Path(ceph_path)
     if not ceph_path.exists():
         rb_folder = ceph_path.parent

--- a/job_controller/utils.py
+++ b/job_controller/utils.py
@@ -56,14 +56,14 @@ def load_kubernetes_config() -> None:
             config.load_kube_config()
 
 
-def ensure_ceph_path_exists(ceph_path: str) -> str:
+def ensure_ceph_path_exists(ceph_path_str: str) -> str:
     """
     Takes a path that is intended to be on ceph and ensures that it will be correct for what we should mount and
     apply output to.
-    :param ceph_path: Is the string path to where we should output to ceph
+    :param ceph_path_str: Is the string path to where we should output to ceph
     :return: The corrected path for output to ceph path
     """
-    ceph_path = Path(ceph_path)
+    ceph_path = Path(ceph_path_str)
     if not ceph_path.exists():
         rb_folder = ceph_path.parent
         if not rb_folder.exists():

--- a/job_controller/utils.py
+++ b/job_controller/utils.py
@@ -4,6 +4,7 @@ A general utilities module for code that may or may not be reused throughout thi
 import logging
 import os
 import sys
+from pathlib import Path
 from typing import List
 from kubernetes import config  # type: ignore[import]
 from kubernetes.config import ConfigException  # type: ignore[import]
@@ -53,3 +54,17 @@ def load_kubernetes_config() -> None:
             config.load_kube_config(config_file=kubeconfig_path)
         else:
             config.load_kube_config()
+
+
+def ensure_ceph_path_exists(ceph_path: str) -> str:
+    ceph_path = Path(ceph_path)
+    if not ceph_path.exists():
+        rb_folder = ceph_path.parent
+        if not rb_folder.exists():
+            # Set parent to unknown
+            rb_folder = rb_folder.with_name("unknown")
+            ceph_path = rb_folder.joinpath(ceph_path.name)
+        if not ceph_path.exists():
+            ceph_path.mkdir(parents=True, exist_ok=True)
+
+    return str(ceph_path)

--- a/test/test_job_controller.py
+++ b/test/test_job_controller.py
@@ -31,6 +31,10 @@ class JobControllerTest(unittest.TestCase):
     @mock.patch("job_controller.main.create_ceph_path")
     def test_on_message_calls_spawn_pod_with_message(self, create_ceph_path, acquire_script, _):
         message = mock.MagicMock()
+        path = "/tmp/ceph/mari/RBNumber/RB000001/autoreduced"
+        create_ceph_path.return_value = path
+        if not os.path.exists(path):
+            os.makedirs(path)
 
         self.joc.on_message(message)
 
@@ -40,6 +44,7 @@ class JobControllerTest(unittest.TestCase):
         )
         self.assertEqual(self.joc.job_creator.spawn_job.call_args.kwargs["script"], acquire_script.return_value)
         self.assertEqual(self.joc.job_creator.spawn_job.call_args.kwargs["ceph_path"], create_ceph_path.return_value)
+        os.removedirs(path)
 
     @mock.patch("job_controller.main.acquire_script")
     @mock.patch("job_controller.main.create_ceph_path")
@@ -70,7 +75,8 @@ class JobControllerTest(unittest.TestCase):
 
     @mock.patch("job_controller.main.acquire_script")
     @mock.patch("job_controller.main.create_ceph_path")
-    def test_on_message_sends_the_job_to_the_job_watch(self, create_ceph_path, aquire_script):
+    @mock.patch("job_controller.main.ensure_ceph_path_exists")
+    def test_on_message_sends_the_job_to_the_job_watch(self, ensure_ceph_path_exists, _, aquire_script):
         message = mock.MagicMock()
         self.joc.create_job_watcher = mock.MagicMock()
 
@@ -78,7 +84,7 @@ class JobControllerTest(unittest.TestCase):
 
         self.joc.create_job_watcher.assert_called_once_with(
             self.joc.job_creator.spawn_job.return_value,
-            create_ceph_path.return_value,
+            ensure_ceph_path_exists.return_value,
             self.joc.db_updater.add_detected_run.return_value,
             aquire_script.return_value,
             message["additional_values"],
@@ -92,9 +98,8 @@ class JobControllerTest(unittest.TestCase):
         def exception_side_effect(*_, **__):
             raise exception
 
-        self.joc.job_creator.spawn_job = mock.MagicMock(side_effect=exception_side_effect)
-
-        self.joc.on_message(message)
+        with mock.patch("job_controller.main.create_ceph_path", side_effect=exception_side_effect):
+            self.joc.on_message(message)
 
         logger.exception.assert_called_once_with(exception)
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -51,4 +51,3 @@ class UtilTests(unittest.TestCase):
 
         self.assertEqual(end_path, "/tmp/ceph/mari/RBNumber/unknown/autoreduced")
         os.removedirs("/tmp/ceph/mari/RBNumber/unknown/autoreduced")
-

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -5,7 +5,7 @@ from unittest import mock
 
 from kubernetes.config import ConfigException
 
-from job_controller.utils import load_kubernetes_config
+from job_controller.utils import load_kubernetes_config, ensure_ceph_path_exists
 
 
 class UtilTests(unittest.TestCase):
@@ -43,3 +43,12 @@ class UtilTests(unittest.TestCase):
 
         kubernetes_config.load_incluster_config.assert_called_once_with()
         kubernetes_config.load_kube_config.assert_called_once_with()
+
+    def test_ensure_ceph_path_exists(self):
+        initial_path = "/tmp/ceph/mari/RBNumber/RB99999999/autoreduced/"
+
+        end_path = ensure_ceph_path_exists(initial_path)
+
+        self.assertEqual(end_path, "/tmp/ceph/mari/RBNumber/unknown/autoreduced")
+        os.removedirs("/tmp/ceph/mari/RBNumber/unknown/autoreduced")
+


### PR DESCRIPTION
Closes #26 and Closes #23

## Description
In the scenario that the autoreduced folder does not exist, or the RB number does not exist, it is all correctly handled now, and ensures that the correct directories are used as per agreement with CEPH admins, as well as the autoreduced folder exists.