### PR TITLE
Add backoffLimit

### DIFF
--- a/job_controller/job_creator.py
+++ b/job_controller/job_creator.py
@@ -39,6 +39,7 @@ class JobCreator:
             kind="Job",
             metadata={"name": job_name},
             spec={
+                "backoffLimit": 1,
                 "ttlSecondsAfterFinished": 21600,  # 6 hours
                 "template": {
                     "spec": {

--- a/test/test_job_creator.py
+++ b/test/test_job_creator.py
@@ -32,6 +32,10 @@ class JobCreatorTest(unittest.TestCase):
         pod_metadata = k8s_pod_call_kwargs["metadata"]
         self.assertEqual(pod_metadata["name"], job_name)
 
+        pod_spec = k8s_pod_call_kwargs["spec"]
+        self.assertEqual(pod_spec["backoffLimit"], 1)
+        self.assertEqual(pod_spec["ttlSecondsAfterFinished"], 21600)
+
         security_context = k8s_pod_call_kwargs["spec"]["template"]["spec"]["security_context"]
         self.assertEqual({"runAsUser": user_id}, security_context)
 


### PR DESCRIPTION
Closes None

## Description
I noted an issue with the number of times a job is attempted and noted that there was no benefit to trying 6 times vs 1, this ensures that the job only tries once.