### PR TITLE
Add call to pre_ping

### DIFF
--- a/job_controller/database/db_updater.py
+++ b/job_controller/database/db_updater.py
@@ -172,7 +172,7 @@ class DBUpdater:
 
     def __init__(self, ip: str, username: str, password: str):
         connection_string = f"postgresql+psycopg2://{username}:{password}@{ip}:5432/interactive-reduction"
-        engine = create_engine(connection_string, poolclass=QueuePool, pool_size=20)
+        engine = create_engine(connection_string, poolclass=QueuePool, pool_size=20, pool_pre_ping=True)
         self.session_maker_func = sessionmaker(bind=engine)
         self.runs_table = Run()
         self.reductions_table = Reduction()


### PR DESCRIPTION
Closes None, Part of a series of fixes that should improve the reliability of connection with the DB

## Description
SQLAlchemy will attempt to use a dead connection if we don't ask it to check if its connections are still functional or not.