### PR TITLE
Improve logging clarity and boost mantid version of runner

### DIFF
--- a/container/Mantid.user.properties
+++ b/container/Mantid.user.properties
@@ -58,7 +58,13 @@ defaultsave.directory=/output
 ## Uncomment to change logging level
 ## Default is notice
 ## Valid values are: error, warning, notice, information, debug
-logging.loggers.root.level=debug
+logging.loggers.root.level=notice
+
+## Instrument file
+UpdateInstrumentDefinitions.OnStartup=0
+
+## Usage reporting
+usagereports.enabled=0
 
 ##
 ## MantidWorkbench

--- a/container/mantid-environment.yml
+++ b/container/mantid-environment.yml
@@ -5,5 +5,5 @@ channels:
   - mantid
 
 dependencies:
-  - mantid=6.6.0
+  - mantid=6.7.0
   - requests

--- a/container/runner.D
+++ b/container/runner.D
@@ -15,6 +15,9 @@ RUN conda init bash
 RUN echo "conda activate mantid" > ~/.bashrc
 ENV PATH /opt/conda/envs/mantid/bin:$PATH
 
+# Run the DownloadInstrument algorithm to get instrument definitions
+RUN python -c "from mantid.simpleapi import DownloadInstrument;DownloadInstrument()"
+
 # Create a shell script to run the python command:
 RUN echo '#!/bin/bash\npython -c "$@"' > /entrypoint.sh
 RUN chmod +x /entrypoint.sh


### PR DESCRIPTION
Closes None

## Description
- Boost mantid version to 6.7
- Pre-download instrument data to avoid issues with github in prod
- Reduce default logging to reduce log spam for clarity in debugging prod