### PR TITLE
Use a PV and PVC for access to the archive

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -185,7 +185,8 @@ good-names=i,
            ___,
            id,
            ip,
-           v1
+           v1,
+           pv
 
 # Good variable names regexes, separated by a comma. If names match any regex,
 # they will always be accepted

--- a/container/runner.D
+++ b/container/runner.D
@@ -16,7 +16,7 @@ RUN echo "conda activate mantid" > ~/.bashrc
 ENV PATH /opt/conda/envs/mantid/bin:$PATH
 
 # Run the DownloadInstrument algorithm to get instrument definitions
-RUN python -c "from mantid.simpleapi import DownloadInstrument;DownloadInstrument()"
+#RUN python -c "from mantid.simpleapi import DownloadInstrument;DownloadInstrument()"
 
 # Create a shell script to run the python command:
 RUN echo '#!/bin/bash\npython -c "$@"' > /entrypoint.sh

--- a/container/runner.D
+++ b/container/runner.D
@@ -16,7 +16,7 @@ RUN echo "conda activate mantid" > ~/.bashrc
 ENV PATH /opt/conda/envs/mantid/bin:$PATH
 
 # Run the DownloadInstrument algorithm to get instrument definitions
-#RUN python -c "from mantid.simpleapi import DownloadInstrument;DownloadInstrument()"
+RUN python -c "from mantid.simpleapi import DownloadInstrument;DownloadInstrument()"
 
 # Create a shell script to run the python command:
 RUN echo '#!/bin/bash\npython -c "$@"' > /entrypoint.sh

--- a/job_controller/job_creator.py
+++ b/job_controller/job_creator.py
@@ -112,7 +112,8 @@ class JobCreator:
                         "restartPolicy": "Never",
                         "tolerations": [{"key": "queue-worker", "effect": "NoSchedule", "operator": "Exists"}],
                         "volumes": [
-                            {"name": "archive-mount", "hostPath": {"type": "Directory", "path": "/archive"}},
+                            {"name": "archive-mount",
+                             "persistentVolumeClaim": {"claimName": f"{job_name}-archive-pv-smb", "readOnly": True}},
                             {"name": "ceph-mount", "hostPath": {"type": "Directory", "path": ceph_path}},
                         ],
                     },

--- a/job_controller/job_creator.py
+++ b/job_controller/job_creator.py
@@ -113,7 +113,7 @@ class JobCreator:
                         "tolerations": [{"key": "queue-worker", "effect": "NoSchedule", "operator": "Exists"}],
                         "volumes": [
                             {"name": "archive-mount",
-                             "persistentVolumeClaim": {"claimName": f"{job_name}-archive-pv-smb", "readOnly": True}},
+                             "persistentVolumeClaim": {"claimName": f"{job_name}-archive-pvc", "readOnly": True}},
                             {"name": "ceph-mount", "hostPath": {"type": "Directory", "path": ceph_path}},
                         ],
                     },

--- a/job_controller/job_watcher.py
+++ b/job_controller/job_watcher.py
@@ -205,7 +205,7 @@ class JobWatcher:  # pylint: disable=too-many-instance-attributes
         else:
             logger.info("Delivered message to %s [%s]", msg.topic(), msg.partition())
 
-    def clean_up_pv_and_pvc(self):
+    def clean_up_pv_and_pvc(self) -> None:
         """
         Clean up the PV and PVC created for the jobs
         :return: None

--- a/job_controller/job_watcher.py
+++ b/job_controller/job_watcher.py
@@ -216,11 +216,11 @@ class JobWatcher:  # pylint: disable=too-many-instance-attributes
         else:
             logger.info("PV %s does not exist", self.pv_name)
         logger.info("Check PVC %s exists", self.pvc_name)
-        if self.pvc_name in \
-                [ii.metadata.name for ii in v1.list_namespaced_persistent_volume_claim(self.namespace).items]:
+        if self.pvc_name in [
+            ii.metadata.name for ii in v1.list_namespaced_persistent_volume_claim(self.namespace).items
+        ]:
             logger.info("PVC %s exists, removing", self.pvc_name)
             v1.delete_namespaced_persistent_volume_claim(self.pvc_name, self.namespace)
             logger.info("PVC %s removed", self.pvc_name)
         else:
             logger.info("PVC %s does not exist", self.pvc_name)
-

--- a/job_controller/job_watcher.py
+++ b/job_controller/job_watcher.py
@@ -206,6 +206,10 @@ class JobWatcher:  # pylint: disable=too-many-instance-attributes
             logger.info("Delivered message to %s [%s]", msg.topic(), msg.partition())
 
     def clean_up_pv_and_pvc(self):
+        """
+        Clean up the PV and PVC created for the jobs
+        :return: None
+        """
         logger.info("Removing PVCs and PVs")
         v1 = client.CoreV1Api()
         logger.info("Check PV %s exists", self.pv_name)

--- a/job_controller/main.py
+++ b/job_controller/main.py
@@ -101,6 +101,8 @@ class JobController:  # pylint: disable=too-many-instance-attributes
     def create_job_watcher(  # pylint: disable=too-many-arguments
         self,
         job_name: str,
+        pv: str, 
+        pvc: str,
         ceph_path: str,
         db_reduction_id: int,
         job_script: str,
@@ -121,6 +123,8 @@ class JobController:  # pylint: disable=too-many-instance-attributes
         """
         watcher = JobWatcher(
             job_name,
+            pv,
+            pvc,
             self.ir_k8s_api,
             self.broker_ip,
             ceph_path,

--- a/job_controller/main.py
+++ b/job_controller/main.py
@@ -101,7 +101,7 @@ class JobController:  # pylint: disable=too-many-instance-attributes
     def create_job_watcher(  # pylint: disable=too-many-arguments
         self,
         job_name: str,
-        pv: str, 
+        pv: str,
         pvc: str,
         ceph_path: str,
         db_reduction_id: int,

--- a/job_controller/main.py
+++ b/job_controller/main.py
@@ -87,14 +87,14 @@ class JobController:  # pylint: disable=too-many-instance-attributes
                 instrument=instrument_name,
             )
             ceph_path = ensure_ceph_path_exists(ceph_path)
-            job = self.job_creator.spawn_job(
+            job, pv, pvc = self.job_creator.spawn_job(
                 job_name=job_name,
                 script=script,
                 ceph_path=ceph_path,
                 job_namespace=self.ir_k8s_api,
                 user_id=self.reduce_user_id,
             )
-            self.create_job_watcher(job, ceph_path, db_reduction_id, script, script_sha, additional_values)
+            self.create_job_watcher(job, pv, pvc, ceph_path, db_reduction_id, script, script_sha, additional_values)
         except Exception as exception:  # pylint: disable=broad-exception-caught
             logger.exception(exception)
 

--- a/test/test_job_creator.py
+++ b/test/test_job_creator.py
@@ -48,8 +48,13 @@ class JobCreatorTest(unittest.TestCase):
         self.assertIn({"name": "ceph-mount", "mountPath": "/output"}, pod_container["volumeMounts"])
 
         volumes = k8s_pod_call_kwargs["spec"]["template"]["spec"]["volumes"]
-        self.assertIn({"name": "archive-mount", "persistentVolumeClaim": {"claimName": f"{job_name}-archive-pvc",
-                                                                          "readOnly": True}}, volumes)
+        self.assertIn(
+            {
+                "name": "archive-mount",
+                "persistentVolumeClaim": {"claimName": f"{job_name}-archive-pvc", "readOnly": True},
+            },
+            volumes,
+        )
         self.assertIn({"name": "ceph-mount", "hostPath": {"type": "Directory", "path": ceph_path}}, volumes)
         self.assertEqual(len(volumes), 2)
 
@@ -112,8 +117,10 @@ class JobCreatorTest(unittest.TestCase):
         self.assertEqual(spec["accessModes"], ["ReadOnlyMany"])
         self.assertEqual(spec["persistentVolumeReclaimPolicy"], "Retain")
         self.assertEqual(spec["storageClassName"], "smb")
-        self.assertListEqual(spec["mountOptions"], ["noserverino", "_netdev", "vers=2.1", "uid=1001", "gid=1001",
-                                                    "dir_mode=0555", "file_mode=0444"])
+        self.assertListEqual(
+            spec["mountOptions"],
+            ["noserverino", "_netdev", "vers=2.1", "uid=1001", "gid=1001", "dir_mode=0555", "file_mode=0444"],
+        )
 
         csi = spec["csi"]
         self.assertEqual(csi["driver"], "smb.csi.k8s.io")

--- a/test/test_job_creator.py
+++ b/test/test_job_creator.py
@@ -48,7 +48,8 @@ class JobCreatorTest(unittest.TestCase):
         self.assertIn({"name": "ceph-mount", "mountPath": "/output"}, pod_container["volumeMounts"])
 
         volumes = k8s_pod_call_kwargs["spec"]["template"]["spec"]["volumes"]
-        self.assertIn({"name": "archive-mount", "hostPath": {"type": "Directory", "path": "/archive"}}, volumes)
+        self.assertIn({"name": "archive-mount", "persistentVolumeClaim": {"claimName": f"{job_name}-archive-pvc",
+                                                                          "readOnly": True}}, volumes)
         self.assertIn({"name": "ceph-mount", "hostPath": {"type": "Directory", "path": ceph_path}}, volumes)
         self.assertEqual(len(volumes), 2)
 
@@ -56,3 +57,68 @@ class JobCreatorTest(unittest.TestCase):
         self.assertEqual(
             kubernetes_client.BatchV1Api.return_value.create_namespaced_job.call_args.kwargs["namespace"], job_namespace
         )
+
+    @mock.patch("job_controller.job_creator.client")
+    @mock.patch("job_controller.job_creator.load_kubernetes_config")
+    def test_spawn_pod_creates_pvc_with_passed_values(self, _, kubernetes_client):
+        script = mock.MagicMock()
+        ceph_path = mock.MagicMock()
+        job_name = mock.MagicMock()
+        job_namespace = mock.MagicMock()
+        user_id = mock.MagicMock()
+        runner_sha = mock.MagicMock()
+        k8s = JobCreator(runner_sha)
+
+        k8s.spawn_job(
+            job_name=job_name, job_namespace=job_namespace, script=script, ceph_path=ceph_path, user_id=user_id
+        )
+
+        k8s_pod_call_kwargs = kubernetes_client.V1PersistentVolumeClaim.call_args_list[0].kwargs
+        self.assertEqual(k8s_pod_call_kwargs["kind"], "PersistentVolumeClaim")
+
+        metadata = k8s_pod_call_kwargs["metadata"]
+        self.assertEqual(metadata["name"], f"{job_name}-archive-pvc")
+
+        spec = k8s_pod_call_kwargs["spec"]
+        self.assertEqual(spec["accessModes"], ["ReadOnlyMany"])
+        self.assertEqual(spec["resources"]["requests"]["storage"], "1000Gi")
+        self.assertEqual(spec["volumeName"], f"{job_name}-archive-pv-smb")
+        self.assertEqual(spec["storageClassName"], "smb")
+
+    @mock.patch("job_controller.job_creator.client")
+    @mock.patch("job_controller.job_creator.load_kubernetes_config")
+    def test_spawn_pod_creates_pv_with_passed_values(self, _, kubernetes_client):
+        script = mock.MagicMock()
+        ceph_path = mock.MagicMock()
+        job_name = mock.MagicMock()
+        job_namespace = mock.MagicMock()
+        user_id = mock.MagicMock()
+        runner_sha = mock.MagicMock()
+        k8s = JobCreator(runner_sha)
+
+        k8s.spawn_job(
+            job_name=job_name, job_namespace=job_namespace, script=script, ceph_path=ceph_path, user_id=user_id
+        )
+
+        k8s_pod_call_kwargs = kubernetes_client.V1PersistentVolume.call_args_list[0].kwargs
+        self.assertEqual(k8s_pod_call_kwargs["kind"], "PersistentVolume")
+
+        metadata = k8s_pod_call_kwargs["metadata"]
+        self.assertEqual(metadata["annotations"]["pv.kubernetes.io/provisioned-by"], "smb.csi.k8s.io")
+        self.assertEqual(metadata["name"], f"{job_name}-archive-pv-smb")
+
+        spec = k8s_pod_call_kwargs["spec"]
+        self.assertEqual(spec["capacity"]["storage"], "1000Gi")
+        self.assertEqual(spec["accessModes"], ["ReadOnlyMany"])
+        self.assertEqual(spec["persistentVolumeReclaimPolicy"], "Retain")
+        self.assertEqual(spec["storageClassName"], "smb")
+        self.assertListEqual(spec["mountOptions"], ["noserverino", "_netdev", "vers=2.1", "uid=1001", "gid=1001",
+                                                    "dir_mode=0555", "file_mode=0444"])
+
+        csi = spec["csi"]
+        self.assertEqual(csi["driver"], "smb.csi.k8s.io")
+        self.assertEqual(csi["readOnly"], True)
+        self.assertEqual(csi["volumeHandle"], "archive.ir.svc.cluster.local/share##archive")
+        self.assertEqual(csi["volumeAttributes"]["source"], "//isisdatar55.isis.cclrc.ac.uk/inst$/")
+        self.assertEqual(csi["nodeStageSecretRef"]["name"], "archive-creds")
+        self.assertEqual(csi["nodeStageSecretRef"]["namespace"], "ir")

--- a/test/test_job_watcher.py
+++ b/test/test_job_watcher.py
@@ -216,4 +216,6 @@ class JobWatcherTest(unittest.TestCase):
 
         self.job_watcher.clean_up_pv_and_pvc()
 
-        client.CoreV1Api.return_value.delete_namespaced_persistent_volume_claim.assert_called_once_with(pvc_name, self.job_watcher.namespace)
+        client.CoreV1Api.return_value.delete_namespaced_persistent_volume_claim.assert_called_once_with(
+            pvc_name, self.job_watcher.namespace
+        )

--- a/test/test_job_watcher.py
+++ b/test/test_job_watcher.py
@@ -11,6 +11,8 @@ class JobWatcherTest(unittest.TestCase):
     @mock.patch("job_controller.job_watcher.load_kubernetes_config")
     def setUp(self, _):
         self.job_name = mock.MagicMock()
+        self.pv_name = mock.MagicMock()
+        self.pvc_name = mock.MagicMock()
         self.namespace = mock.MagicMock()
         self.kafka_ip = mock.MagicMock()
         self.ceph_path = mock.MagicMock()
@@ -21,6 +23,8 @@ class JobWatcherTest(unittest.TestCase):
         self.reduction_inputs = mock.MagicMock()
         self.job_watcher = JobWatcher(
             job_name=self.job_name,
+            pv_name=self.pv_name,
+            pvc_name=self.pvc_name,
             namespace=self.namespace,
             kafka_ip=self.kafka_ip,
             ceph_path=self.ceph_path,
@@ -33,7 +37,7 @@ class JobWatcherTest(unittest.TestCase):
 
     @mock.patch("job_controller.job_watcher.load_kubernetes_config")
     def test_ensure_init_load_kube_config(self, load_kube_config):
-        JobWatcher("", "", "", "", mock.MagicMock(), 1, "", "", {})
+        JobWatcher("", "", "", "", "", "", mock.MagicMock(), 1, "", "", {})
 
         load_kube_config.assert_called_once_with()
 


### PR DESCRIPTION
An overarching issue as part of: https://github.com/interactivereduction/gitops/issues/4

## Description
Effectively create, use, and then destroy Persistent Volumes and Persistent Volume Claims using the CSI driver for smb in the Kubernetes cluster for usage by the jobs.