### PR TITLE
Use NullPool

### DIFF
--- a/job_controller/database/db_updater.py
+++ b/job_controller/database/db_updater.py
@@ -12,7 +12,7 @@ from sqlalchemy import (  # type: ignore[attr-defined]
     String,
     DateTime,
     ForeignKey,
-    QueuePool,
+    NullPool,
     Enum,
 )
 from sqlalchemy.dialects.postgresql import JSONB
@@ -173,7 +173,7 @@ class DBUpdater:
 
     def __init__(self, ip: str, username: str, password: str):
         connection_string = f"postgresql+psycopg2://{username}:{password}@{ip}:5432/interactive-reduction"
-        engine = create_engine(connection_string, poolclass=QueuePool, pool_size=20, pool_pre_ping=True)
+        engine = create_engine(connection_string, poolclass=NullPool)
         self.session_maker_func = sessionmaker(bind=engine)
 
     # pylint: disable=too-many-arguments, too-many-locals


### PR DESCRIPTION
Closes # No issue

## Description
A problem was noted in staging in Cycle 23/03 with the new RabbitMQ migration, specifically the blocking connection causes the pool connections to become stale. Stale connections cause issues with ingesting and causes messages to become lost and data loss.