### PR TITLE
Add support for ngem imat workflows

### DIFF
--- a/job_creator/jobcreator/job_creator.py
+++ b/job_creator/jobcreator/job_creator.py
@@ -179,6 +179,7 @@ def _setup_ngem_pv_and_pvcs(job_name: str, namespace: str, pv_names: list[str], 
     pv_names.append(ngem_pv_name)
     pvc_names.append(ngem_pvc_name)
 
+
 def _setup_imat_pv_and_pvcs(job_name: str, namespace: str, pv_names: list[str], pvc_names: list[str]) -> None:
     imat_pv_name = f"{job_name}-ndximat-pv-smb"
     imat_pvc_name = f"{job_name}-ndximat-pvc"

--- a/job_creator/jobcreator/job_creator.py
+++ b/job_creator/jobcreator/job_creator.py
@@ -9,7 +9,14 @@ from kubernetes import client  # type: ignore[import-untyped]
 from jobcreator.utils import load_kubernetes_config, logger
 
 
-def _setup_smb_pv(pv_name: str, secret_name: str, secret_namespace: str, source: str, mount_options: list[str]) -> None:
+def _setup_smb_pv(
+    pv_name: str,
+    secret_name: str,
+    secret_namespace: str,
+    source: str,
+    mount_options: list[str],
+    access_mode: str = "ReadOnlyMany",
+) -> None:
     """
     Sets up an smb PV using the loaded kubeconfig as a destination
     :param pv_name: str, The name given to the smb-pv when it's made
@@ -17,7 +24,8 @@ def _setup_smb_pv(pv_name: str, secret_name: str, secret_namespace: str, source:
     :param secret_namespace: str, the namespace of the secret
     :param source: str, The IP/url/uri that is used to mount the smb share
     :param mount_options: list, The mount options for the smb share
-    :return: str, the name of the archive PV
+    :param access_mode: str, The access mode for the PV. Defaults to "ReadOnlyMany"
+    :return: str, the name of the PV
     """
     metadata = client.V1ObjectMeta(name=pv_name, annotations={"pv.kubernetes.io/provisioned-by": "smb.csi.k8s.io"})
     secret_ref = client.V1SecretReference(name=secret_name, namespace=secret_namespace)
@@ -30,13 +38,13 @@ def _setup_smb_pv(pv_name: str, secret_name: str, secret_namespace: str, source:
     )
     spec = client.V1PersistentVolumeSpec(
         capacity={"storage": "1000Gi"},
-        access_modes=["ReadOnlyMany"],
+        access_modes=[access_mode],
         persistent_volume_reclaim_policy="Retain",
         mount_options=mount_options,
         csi=csi,
     )
-    archive_pv = client.V1PersistentVolume(api_version="v1", kind="PersistentVolume", metadata=metadata, spec=spec)
-    client.CoreV1Api().create_persistent_volume(archive_pv)
+    pv = client.V1PersistentVolume(api_version="v1", kind="PersistentVolume", metadata=metadata, spec=spec)
+    client.CoreV1Api().create_persistent_volume(pv)
 
 
 def _setup_pvc(pvc_name: str, pv_name: str, namespace: str, access_mode: str = "ReadOnlyMany") -> None:
@@ -162,6 +170,14 @@ def _setup_ceph_pv(
     client.CoreV1Api().create_persistent_volume(ceph_pv)
     return pv_name
 
+
+def _setup_ngem_pv_and_pvcs(job_name: str, namespace: str, pv_names: list[str], pvc_names: list[str]) -> None:
+    ngem_pv_name = f"{job_name}-ngem-pv-smb"
+    ngem_pvc_name = f"{job_name}-ngem-pvc"
+    _setup_smb_pv(ngem_pv_name, "archive-creds", namespace, "//isis.cclrc.ac.uk/Science", [], "ReadWriteMany")
+    _setup_pvc(ngem_pvc_name, ngem_pv_name, namespace, "ReadWriteMany")
+    pv_names.append(ngem_pv_name)
+    pvc_names.append(ngem_pvc_name)
 
 def _setup_imat_pv_and_pvcs(job_name: str, namespace: str, pv_names: list[str], pvc_names: list[str]) -> None:
     imat_pv_name = f"{job_name}-ndximat-pv-smb"
@@ -385,6 +401,13 @@ class JobCreator:
             client.V1VolumeMount(name="extras-mount", mount_path="/extras"),
         ]
         # Setup special PVs and add them to the volume mounts
+        if "ngem" in special_pvs:
+            _setup_ngem_pv_and_pvcs(job_name, job_namespace, pv_names, pvc_names)
+            ngem_pvc_source = client.V1PersistentVolumeClaimVolumeSource(
+                claim_name=f"{job_name}-ngem-pvc", read_only=False
+            )
+            volumes.append(client.V1Volume(name="ngem-mount", persistent_volume_claim=ngem_pvc_source))
+            volumes_mounts.append(client.V1VolumeMount(name="ngem-mount", mount_path="/ngem"))
         if "imat" in special_pvs:
             _setup_imat_pv_and_pvcs(job_name, job_namespace, pv_names, pvc_names)
             imat_pvc_source = client.V1PersistentVolumeClaimVolumeSource(

--- a/job_creator/jobcreator/main.py
+++ b/job_creator/jobcreator/main.py
@@ -50,7 +50,7 @@ JOB_CREATOR: JobCreator | None = None
 
 
 def get_job_creator() -> JobCreator:
-    global JOB_CREATOR
+    global JOB_CREATOR  # noqa: PLW0603
     if JOB_CREATOR is None:
         if WATCHER_SHA is None:
             raise OSError("WATCHER_SHA not set in the environment, please add it.")

--- a/job_creator/jobcreator/main.py
+++ b/job_creator/jobcreator/main.py
@@ -57,6 +57,7 @@ def get_job_creator() -> JobCreator:
         JOB_CREATOR = JobCreator(dev_mode=DEV_MODE, watcher_sha=WATCHER_SHA)
     return JOB_CREATOR
 
+
 CEPH_CREDS_SECRET_NAME = os.environ.get("CEPH_CREDS_SECRET_NAME", "ceph-creds")
 CEPH_CREDS_SECRET_NAMESPACE = os.environ.get("CEPH_CREDS_SECRET_NAMESPACE", "fia")
 CLUSTER_ID = os.environ.get("CLUSTER_ID", "ba68226a-672f-4ba5-97bc-22840318b2ec")

--- a/job_creator/jobcreator/main.py
+++ b/job_creator/jobcreator/main.py
@@ -59,7 +59,7 @@ MANILA_SHARE_ACCESS_ID = os.environ.get("MANILA_SHARE_ACCESS_ID", "8045701a-0c3e
 MAX_TIME_TO_COMPLETE = int(os.environ.get("MAX_TIME_TO_COMPLETE", str(60 * 60 * 6)))
 
 
-def _generate_special_pvs(instrument: str, additional_values: dict) -> list[str]:
+def _generate_special_pvs(instrument: str, additional_values: dict[str, Any]) -> list[str]:
     """
     A generic function for, based on passed args, returning what the special persistent volumes should be.
     """
@@ -84,7 +84,7 @@ def _generate_special_pvs(instrument: str, additional_values: dict) -> list[str]
     return special_pvs
 
 
-def _select_runner_image(instrument: str, additional_values: dict) -> str:
+def _select_runner_image(instrument: str, additional_values: dict[str, Any]) -> str:
     """
     A generic function for, based on passed args, returning what the runner that should be used.
     """
@@ -103,9 +103,7 @@ def _select_runner_image(instrument: str, additional_values: dict) -> str:
             return DEFAULT_RUNNER
 
 
-def _select_taints_and_affinity(
-    instrument: str, additional_values: dict
-) -> tuple[list[dict[str, Any]], dict[str, Any] | None]:
+def _select_taints_and_affinity(instrument: str, additional_values: dict[str, Any]) -> tuple[list[dict[str, Any]], dict[str, Any] | None]:
     """
     A generic function for, based on passed args, returning what the runner that should be used.
     """

--- a/job_creator/jobcreator/main.py
+++ b/job_creator/jobcreator/main.py
@@ -103,7 +103,9 @@ def _select_runner_image(instrument: str, additional_values: dict[str, Any]) -> 
             return DEFAULT_RUNNER
 
 
-def _select_taints_and_affinity(instrument: str, additional_values: dict[str, Any]) -> tuple[list[dict[str, Any]], dict[str, Any] | None]:
+def _select_taints_and_affinity(
+    instrument: str, additional_values: dict[str, Any]
+) -> tuple[list[dict[str, Any]], dict[str, Any] | None]:
     """
     A generic function for, based on passed args, returning what the runner that should be used.
     """

--- a/job_creator/jobcreator/main.py
+++ b/job_creator/jobcreator/main.py
@@ -103,7 +103,9 @@ def _select_runner_image(instrument: str, additional_values: dict) -> str:
             return DEFAULT_RUNNER
 
 
-def _select_taints_and_affinity(instrument: str, additional_values: dict) -> tuple[list[dict[str, Any]], dict[str, Any] | None]:
+def _select_taints_and_affinity(
+    instrument: str, additional_values: dict
+) -> tuple[list[dict[str, Any]], dict[str, Any] | None]:
     """
     A generic function for, based on passed args, returning what the runner that should be used.
     """
@@ -198,8 +200,12 @@ def process_rerun_message(message: dict[str, Any]) -> None:
             rb_number=str(message["rb_number"]),
         )
 
-        special_pvs = _generate_special_pvs(instrument=message["instrument"], additional_values=message.get("additional_values", {}))
-        taints, affinity = _select_taints_and_affinity(instrument=message["instrument"], additional_values=message.get("additional_values", {}))
+        special_pvs = _generate_special_pvs(
+            instrument=message["instrument"], additional_values=message.get("additional_values", {})
+        )
+        taints, affinity = _select_taints_and_affinity(
+            instrument=message["instrument"], additional_values=message.get("additional_values", {})
+        )
 
         # Add UUID which will avoid collisions for reruns
         job_name = f"run-{str(message['filename']).lower()}-{uuid.uuid4().hex!s}"
@@ -256,7 +262,9 @@ def process_autoreduction_message(message: dict[str, Any]) -> None:
         }
 
         special_pvs = _generate_special_pvs(instrument=instrument_name, additional_values=message["additional_values"])
-        taints, affinity = _select_taints_and_affinity(instrument=message["instrument"], additional_values=message["additional_values"])
+        taints, affinity = _select_taints_and_affinity(
+            instrument=message["instrument"], additional_values=message["additional_values"]
+        )
 
         # Add UUID which will avoid collisions for reruns
         job_name = f"run-{filename.lower()}-{uuid.uuid4().hex!s}"

--- a/job_creator/jobcreator/main.py
+++ b/job_creator/jobcreator/main.py
@@ -46,7 +46,16 @@ CONSUMER_USERNAME = os.environ.get("QUEUE_USER", "")
 CONSUMER_PASSWORD = os.environ.get("QUEUE_PASSWORD", "")
 REDUCE_USER_ID = os.environ.get("REDUCE_USER_ID", "")
 JOB_NAMESPACE = os.environ.get("JOB_NAMESPACE", "fia")
-JOB_CREATOR = JobCreator(dev_mode=DEV_MODE, watcher_sha=WATCHER_SHA)
+JOB_CREATOR: JobCreator | None = None
+
+
+def get_job_creator() -> JobCreator:
+    global JOB_CREATOR
+    if JOB_CREATOR is None:
+        if WATCHER_SHA is None:
+            raise OSError("WATCHER_SHA not set in the environment, please add it.")
+        JOB_CREATOR = JobCreator(dev_mode=DEV_MODE, watcher_sha=WATCHER_SHA)
+    return JOB_CREATOR
 
 CEPH_CREDS_SECRET_NAME = os.environ.get("CEPH_CREDS_SECRET_NAME", "ceph-creds")
 CEPH_CREDS_SECRET_NAMESPACE = os.environ.get("CEPH_CREDS_SECRET_NAMESPACE", "fia")
@@ -161,7 +170,7 @@ def process_simple_message(message: dict[str, Any]) -> None:
             {"user_number": str(user_number)} if user_number else {"experiment_number": str(experiment_number)}
         )
         ceph_mount_path = create_ceph_mount_path_simple(**ceph_mount_path_kwargs)
-        JOB_CREATOR.spawn_job(
+        get_job_creator().spawn_job(
             job_name=job_name,
             script=script,
             job_namespace=JOB_NAMESPACE,
@@ -209,7 +218,7 @@ def process_rerun_message(message: dict[str, Any]) -> None:
 
         # Add UUID which will avoid collisions for reruns
         job_name = f"run-{str(message['filename']).lower()}-{uuid.uuid4().hex!s}"
-        JOB_CREATOR.spawn_job(
+        get_job_creator().spawn_job(
             job_name=job_name,
             script=script,
             job_namespace=JOB_NAMESPACE,
@@ -274,7 +283,7 @@ def process_autoreduction_message(message: dict[str, Any]) -> None:
             autoreduction_request=autoreduction_request,
         )
         ceph_mount_path = create_ceph_mount_path_autoreduction(instrument_name, rb_number)
-        JOB_CREATOR.spawn_job(
+        get_job_creator().spawn_job(
             job_name=job_name,
             script=script,
             job_namespace=JOB_NAMESPACE,

--- a/job_creator/jobcreator/main.py
+++ b/job_creator/jobcreator/main.py
@@ -50,6 +50,8 @@ JOB_CREATOR: JobCreator | None = None
 
 
 def get_job_creator() -> JobCreator:
+    """Use this Singleton pattern to allow for trivial mocking within testing infrastructure, not strictly needed but
+    trivialises test implementation for mocking out the JobCreator."""
     global JOB_CREATOR  # noqa: PLW0603
     if JOB_CREATOR is None:
         if WATCHER_SHA is None:

--- a/job_creator/jobcreator/main.py
+++ b/job_creator/jobcreator/main.py
@@ -59,7 +59,7 @@ MANILA_SHARE_ACCESS_ID = os.environ.get("MANILA_SHARE_ACCESS_ID", "8045701a-0c3e
 MAX_TIME_TO_COMPLETE = int(os.environ.get("MAX_TIME_TO_COMPLETE", str(60 * 60 * 6)))
 
 
-def _generate_special_pvs(instrument: str) -> list[str]:
+def _generate_special_pvs(instrument: str, additional_values: dict) -> list[str]:
     """
     A generic function for, based on passed args, returning what the special persistent volumes should be.
     """
@@ -68,19 +68,31 @@ def _generate_special_pvs(instrument: str) -> list[str]:
     match instrument.lower():
         case "imat":
             logger.info("Special PV for %s added.", instrument)
-            special_pvs.append("imat")
+            if "ngem" in additional_values and additional_values["ngem"] == "true":
+                special_pvs.append("ngem")
+            else:
+                special_pvs.append("imat")
+        case "ines":
+            logger.info("Special PV for %s added.", instrument)
+            if "ngem" in additional_values and additional_values["ngem"] == "true":
+                special_pvs.append("ngem")
+            else:
+                special_pvs.append("ines")
         case _:
             logger.info("No special PV needed for %s", instrument)
 
     return special_pvs
 
 
-def _select_runner_image(instrument: str) -> str:
+def _select_runner_image(instrument: str, additional_values: dict) -> str:
     """
     A generic function for, based on passed args, returning what the runner that should be used.
     """
     match instrument.lower():
         case "imat":
+            if "ngem" in additional_values and additional_values["ngem"] == "true":
+                # For ngem we want to return the default mantid runner. INES always wants mantid default runner.
+                return DEFAULT_RUNNER
             if IMAGING_RUNNER_SHA is not None:
                 logger.info("Imaging runner image selected for %s ", instrument)
                 return IMAGING_RUNNER
@@ -91,7 +103,7 @@ def _select_runner_image(instrument: str) -> str:
             return DEFAULT_RUNNER
 
 
-def _select_taints_and_affinity(instrument: str) -> tuple[list[dict[str, Any]], dict[str, Any] | None]:
+def _select_taints_and_affinity(instrument: str, additional_values: dict) -> tuple[list[dict[str, Any]], dict[str, Any] | None]:
     """
     A generic function for, based on passed args, returning what the runner that should be used.
     """
@@ -100,9 +112,10 @@ def _select_taints_and_affinity(instrument: str) -> tuple[list[dict[str, Any]], 
 
     match instrument.lower():
         case "imat":
-            logger.info("Applying taint to the job on instrument %s", instrument)
-            taints.append({"key": "nvidia.com/gpu", "effect": "NoSchedule", "operator": "Exists"})
-            affinity = {"key": "node-type", "operator": "In", "values": ["gpu-worker"]}
+            if "ngem" not in additional_values or additional_values["ngem"] != "true":
+                logger.info("Applying taint to the job on instrument %s", instrument)
+                taints.append({"key": "nvidia.com/gpu", "effect": "NoSchedule", "operator": "Exists"})
+                affinity = {"key": "node-type", "operator": "In", "values": ["gpu-worker"]}
         case _:
             logger.info("No taints applied to %s runners", instrument)
 
@@ -185,8 +198,8 @@ def process_rerun_message(message: dict[str, Any]) -> None:
             rb_number=str(message["rb_number"]),
         )
 
-        special_pvs = _generate_special_pvs(instrument=message["instrument"])
-        taints, affinity = _select_taints_and_affinity(instrument=message["instrument"])
+        special_pvs = _generate_special_pvs(instrument=message["instrument"], additional_values=message.get("additional_values", {}))
+        taints, affinity = _select_taints_and_affinity(instrument=message["instrument"], additional_values=message.get("additional_values", {}))
 
         # Add UUID which will avoid collisions for reruns
         job_name = f"run-{str(message['filename']).lower()}-{uuid.uuid4().hex!s}"
@@ -226,7 +239,7 @@ def process_autoreduction_message(message: dict[str, Any]) -> None:
         instrument_name = message["instrument"]
         runner_image = message.get("runner_image")
         if runner_image is None:
-            runner_image = _select_runner_image(instrument_name)
+            runner_image = _select_runner_image(instrument_name, message["additional_values"])
         runner_image = find_sha256_of_image(runner_image)
         autoreduction_request = {
             "filename": filename,
@@ -242,8 +255,8 @@ def process_autoreduction_message(message: dict[str, Any]) -> None:
             "runner_image": runner_image,
         }
 
-        special_pvs = _generate_special_pvs(instrument=instrument_name)
-        taints, affinity = _select_taints_and_affinity(instrument=message["instrument"])
+        special_pvs = _generate_special_pvs(instrument=instrument_name, additional_values=message["additional_values"])
+        taints, affinity = _select_taints_and_affinity(instrument=message["instrument"], additional_values=message["additional_values"])
 
         # Add UUID which will avoid collisions for reruns
         job_name = f"run-{filename.lower()}-{uuid.uuid4().hex!s}"

--- a/job_creator/test/test_job_creator.py
+++ b/job_creator/test/test_job_creator.py
@@ -9,6 +9,10 @@ from jobcreator.job_creator import (
     _setup_extras_pvc,
     _setup_pvc,
     _setup_smb_pv,
+    _generate_tolerations_from_taints,
+    _generate_affinities,
+    _setup_ngem_pv_and_pvcs,
+    _setup_imat_pv_and_pvcs,
 )
 
 
@@ -156,6 +160,80 @@ def test_setup_extras_pv(client):
 
 
 @mock.patch("jobcreator.job_creator.client")
+def test_generate_tolerations_from_taints(client):
+    taints = [
+        {"key": "key1", "value": "value1", "operator": "Equal", "effect": "NoSchedule"},
+        {"key": "key2", "operator": "Exists", "effect": "NoExecute"},
+    ]
+    tolerations = _generate_tolerations_from_taints(taints)
+
+    assert len(tolerations) == 2
+    client.V1Toleration.assert_has_calls(
+        [
+            call(key="key1", value="value1", operator="Equal", effect="NoSchedule"),
+            call(key="key2", value=None, operator="Exists", effect="NoExecute"),
+        ]
+    )
+
+
+@mock.patch("jobcreator.job_creator.client")
+def test_generate_affinities_none(client):
+    affinity = _generate_affinities(None)
+    assert affinity == client.V1Affinity.return_value
+    client.V1Affinity.assert_called_once_with(pod_anti_affinity=client.V1PodAntiAffinity.return_value)
+
+
+@mock.patch("jobcreator.job_creator.logger")
+@mock.patch("jobcreator.job_creator.client")
+def test_generate_affinities_missing_key(client, logger):
+    node_affinity_dict = {"key": "some-key", "operator": "In"}  # missing "values"
+    affinity = _generate_affinities(node_affinity_dict)
+    logger.error.assert_called_once()
+    client.V1Affinity.assert_called_once_with(pod_anti_affinity=client.V1PodAntiAffinity.return_value)
+
+
+@mock.patch("jobcreator.job_creator.client")
+def test_generate_affinities_valid(client):
+    node_affinity_dict = {"key": "some-key", "operator": "In", "values": ["val1"]}
+    affinity = _generate_affinities(node_affinity_dict)
+    client.V1Affinity.assert_called_once_with(
+        pod_anti_affinity=client.V1PodAntiAffinity.return_value, node_affinity=client.V1NodeAffinity.return_value
+    )
+
+
+@mock.patch("jobcreator.job_creator._setup_pvc")
+@mock.patch("jobcreator.job_creator._setup_smb_pv")
+def test_setup_ngem_pv_and_pvcs(setup_smb_pv, setup_pvc):
+    pv_names = []
+    pvc_names = []
+    _setup_ngem_pv_and_pvcs("job1", "ns1", pv_names, pvc_names)
+    setup_smb_pv.assert_called_once_with(
+        "job1-ngem-pv-smb", "archive-creds", "ns1", "//isis.cclrc.ac.uk/Science", [], "ReadWriteMany"
+    )
+    setup_pvc.assert_called_once_with("job1-ngem-pvc", "job1-ngem-pv-smb", "ns1", "ReadWriteMany")
+    assert pv_names == ["job1-ngem-pv-smb"]
+    assert pvc_names == ["job1-ngem-pvc"]
+
+
+@mock.patch("jobcreator.job_creator._setup_pvc")
+@mock.patch("jobcreator.job_creator._setup_smb_pv")
+def test_setup_imat_pv_and_pvcs(setup_smb_pv, setup_pvc):
+    pv_names = []
+    pvc_names = []
+    _setup_imat_pv_and_pvcs("job1", "ns1", pv_names, pvc_names)
+    setup_smb_pv.assert_called_once_with(
+        "job1-ndximat-pv-smb",
+        "imat-creds",
+        "ns1",
+        "//NDXIMAT.isis.cclrc.ac.uk/data$/",
+        [],
+    )
+    setup_pvc.assert_called_once_with("job1-ndximat-pvc", "job1-ndximat-pv-smb", "ns1")
+    assert pv_names == ["job1-ndximat-pv-smb"]
+    assert pvc_names == ["job1-ndximat-pvc"]
+
+
+@mock.patch("jobcreator.job_creator.client")
 def test_setup_ceph_pv(client):
     pv_name = mock.MagicMock()
     ceph_creds_k8s_secret_name = mock.MagicMock()
@@ -217,6 +295,61 @@ def test_jobcreator_init(mock_load_kubernetes_config):
     JobCreator("", False)
 
     mock_load_kubernetes_config.assert_called_once()
+
+
+@mock.patch("jobcreator.job_creator._setup_ngem_pv_and_pvcs")
+@mock.patch("jobcreator.job_creator._setup_imat_pv_and_pvcs")
+@mock.patch("jobcreator.job_creator._setup_extras_pv")
+@mock.patch("jobcreator.job_creator._setup_extras_pvc")
+@mock.patch("jobcreator.job_creator._setup_smb_pv")
+@mock.patch("jobcreator.job_creator._setup_pvc")
+@mock.patch("jobcreator.job_creator._setup_ceph_pv")
+@mock.patch("jobcreator.job_creator.load_kubernetes_config")
+@mock.patch("jobcreator.job_creator.client")
+def test_jobcreator_spawn_job_ngem(
+    client,
+    _,  # noqa: PT019
+    setup_ceph_pv,
+    setup_pvc,
+    setup_smb_pv,
+    setup_extras_pvc,
+    setup_extras_pv,
+    setup_imat_pv,
+    setup_ngem_pv,
+):
+    job_name = "test-job"
+    script = "test-script"
+    job_namespace = "test-ns"
+    watcher_sha = "test-sha"
+    job_creator = JobCreator(watcher_sha, False)
+
+    job_creator.spawn_job(
+        job_name=job_name,
+        script=script,
+        job_namespace=job_namespace,
+        ceph_creds_k8s_secret_name="secret",
+        ceph_creds_k8s_namespace="ns",
+        cluster_id="id",
+        fs_name="fs",
+        ceph_mount_path="/path",
+        job_id=1,
+        max_time_to_complete_job=100,
+        fia_api_host="host",
+        fia_api_api_key="key",
+        runner_image="image",
+        manila_share_id="mid",
+        manila_share_access_id="maid",
+        special_pvs=["ngem"],
+        taints=[],
+        affinity=None,
+    )
+
+    setup_ngem_pv.assert_called_once()
+    # Check that ngem volume and volume mount were added
+    # We check if V1Volume was called with name="ngem-mount"
+    assert any(c.kwargs.get('name') == "ngem-mount" for c in client.V1Volume.call_args_list)
+    # Check if V1VolumeMount was called with name="ngem-mount"
+    assert any(c.kwargs.get('name') == "ngem-mount" for c in client.V1VolumeMount.call_args_list)
 
 
 @mock.patch("jobcreator.job_creator._setup_extras_pv")

--- a/job_creator/test/test_job_creator.py
+++ b/job_creator/test/test_job_creator.py
@@ -159,6 +159,9 @@ def test_setup_extras_pv(client):
     client.V1SecretReference.assert_called_once_with(name="manila-creds", namespace=secret_namespace)
 
 
+EXPECTED_TOLERATIONS_COUNT = 2
+
+
 @mock.patch("jobcreator.job_creator.client")
 def test_generate_tolerations_from_taints(client):
     taints = [
@@ -167,7 +170,7 @@ def test_generate_tolerations_from_taints(client):
     ]
     tolerations = _generate_tolerations_from_taints(taints)
 
-    assert len(tolerations) == 2
+    assert len(tolerations) == EXPECTED_TOLERATIONS_COUNT
     client.V1Toleration.assert_has_calls(
         [
             call(key="key1", value="value1", operator="Equal", effect="NoSchedule"),
@@ -327,7 +330,7 @@ def test_jobcreator_spawn_job_ngem(
         job_name=job_name,
         script=script,
         job_namespace=job_namespace,
-        ceph_creds_k8s_secret_name="secret",
+        ceph_creds_k8s_secret_name="some-secret-name",  # noqa: S106
         ceph_creds_k8s_namespace="ns",
         cluster_id="id",
         fs_name="fs",

--- a/job_creator/test/test_job_creator.py
+++ b/job_creator/test/test_job_creator.py
@@ -187,7 +187,7 @@ def test_generate_affinities_none(client):
 @mock.patch("jobcreator.job_creator.client")
 def test_generate_affinities_missing_key(client, logger):
     node_affinity_dict = {"key": "some-key", "operator": "In"}  # missing "values"
-    affinity = _generate_affinities(node_affinity_dict)
+    _generate_affinities(node_affinity_dict)
     logger.error.assert_called_once()
     client.V1Affinity.assert_called_once_with(pod_anti_affinity=client.V1PodAntiAffinity.return_value)
 
@@ -195,7 +195,7 @@ def test_generate_affinities_missing_key(client, logger):
 @mock.patch("jobcreator.job_creator.client")
 def test_generate_affinities_valid(client):
     node_affinity_dict = {"key": "some-key", "operator": "In", "values": ["val1"]}
-    affinity = _generate_affinities(node_affinity_dict)
+    _generate_affinities(node_affinity_dict)
     client.V1Affinity.assert_called_once_with(
         pod_anti_affinity=client.V1PodAntiAffinity.return_value, node_affinity=client.V1NodeAffinity.return_value
     )

--- a/job_creator/test/test_job_creator.py
+++ b/job_creator/test/test_job_creator.py
@@ -4,15 +4,15 @@ from unittest.mock import call
 
 from jobcreator.job_creator import (
     JobCreator,
+    _generate_affinities,
+    _generate_tolerations_from_taints,
     _setup_ceph_pv,
     _setup_extras_pv,
     _setup_extras_pvc,
+    _setup_imat_pv_and_pvcs,
+    _setup_ngem_pv_and_pvcs,
     _setup_pvc,
     _setup_smb_pv,
-    _generate_tolerations_from_taints,
-    _generate_affinities,
-    _setup_ngem_pv_and_pvcs,
-    _setup_imat_pv_and_pvcs,
 )
 
 
@@ -350,9 +350,9 @@ def test_jobcreator_spawn_job_ngem(
     setup_ngem_pv.assert_called_once()
     # Check that ngem volume and volume mount were added
     # We check if V1Volume was called with name="ngem-mount"
-    assert any(c.kwargs.get('name') == "ngem-mount" for c in client.V1Volume.call_args_list)
+    assert any(c.kwargs.get("name") == "ngem-mount" for c in client.V1Volume.call_args_list)
     # Check if V1VolumeMount was called with name="ngem-mount"
-    assert any(c.kwargs.get('name') == "ngem-mount" for c in client.V1VolumeMount.call_args_list)
+    assert any(c.kwargs.get("name") == "ngem-mount" for c in client.V1VolumeMount.call_args_list)
 
 
 @mock.patch("jobcreator.job_creator._setup_extras_pv")

--- a/job_creator/test/test_main.py
+++ b/job_creator/test/test_main.py
@@ -20,6 +20,15 @@ with mock.patch.dict(
     )
 
 
+import jobcreator.main
+
+
+EXPECTED_EXPERIMENT_JOB_ID = 2
+EXPECTED_RERUN_JOB_ID = 100
+EXPECTED_AUTOREDUCTION_JOB_ID = 200
+EXPECTED_AUTO_CALL_COUNT = 2
+
+
 class TestMain(unittest.TestCase):
 
     def test_generate_special_pvs_imat_with_ngem(self):
@@ -123,7 +132,7 @@ class TestMain(unittest.TestCase):
         mock_job_creator.spawn_job.assert_called_once()
         kwargs = mock_job_creator.spawn_job.call_args.kwargs
         assert "run-owner67890-requested-" in kwargs["job_name"]
-        assert kwargs["job_id"] == 2
+        assert kwargs["job_id"] == EXPECTED_EXPERIMENT_JOB_ID
 
     @mock.patch("jobcreator.main.logger")
     def test_process_simple_message_invalid_job_id(self, mock_logger):
@@ -149,7 +158,7 @@ class TestMain(unittest.TestCase):
         mock_job_creator.spawn_job.assert_called_once()
         kwargs = mock_job_creator.spawn_job.call_args.kwargs
         assert "run-data.nxs-" in kwargs["job_name"]
-        assert kwargs["job_id"] == 100
+        assert kwargs["job_id"] == EXPECTED_RERUN_JOB_ID
         assert kwargs["special_pvs"] == ["imat"]
 
     @mock.patch("jobcreator.main.JOB_CREATOR")
@@ -176,7 +185,7 @@ class TestMain(unittest.TestCase):
         mock_job_creator.spawn_job.assert_called_once()
         kwargs = mock_job_creator.spawn_job.call_args.kwargs
         assert "run-data-" in kwargs["job_name"]
-        assert kwargs["job_id"] == 200
+        assert kwargs["job_id"] == EXPECTED_AUTOREDUCTION_JOB_ID
         assert kwargs["script"] == "generated_script"
 
     @mock.patch("jobcreator.main.process_simple_message")
@@ -190,7 +199,7 @@ class TestMain(unittest.TestCase):
         process_message({"job_type": "autoreduction"})
         mock_auto.assert_called_once()
         process_message({})  # defaults to autoreduction
-        assert mock_auto.call_count == 2
+        assert mock_auto.call_count == EXPECTED_AUTO_CALL_COUNT
 
     @mock.patch("jobcreator.main.time")
     @mock.patch("jobcreator.main.Path")
@@ -233,14 +242,16 @@ class TestMain(unittest.TestCase):
 
     @mock.patch("jobcreator.main.main")
     def test_main_coverage(self, mock_main):
-        import jobcreator.main
-
         # Test missing DEFAULT_RUNNER_SHA
-        with mock.patch.dict(os.environ, {"WATCHER_SHA": "watcher-sha"}, clear=True), pytest.raises(OSError):
+        with mock.patch.dict(os.environ, {"WATCHER_SHA": "watcher-sha"}, clear=True), pytest.raises(
+            OSError, match="DEFAULT_RUNNER_SHA"
+        ):
             importlib.reload(jobcreator.main)
 
         # Test missing WATCHER_SHA
-        with mock.patch.dict(os.environ, {"DEFAULT_RUNNER_SHA": "default-sha"}, clear=True), pytest.raises(OSError):
+        with mock.patch.dict(os.environ, {"DEFAULT_RUNNER_SHA": "default-sha"}, clear=True), pytest.raises(
+            OSError, match="WATCHER_SHA"
+        ):
             importlib.reload(jobcreator.main)
 
         # Test DEV_MODE branch
@@ -261,5 +272,5 @@ class TestMain(unittest.TestCase):
             source = "if __name__ == '__main__': main()"
             exec_globals = {"main": mock_main, "__name__": "__main__"}
             # noqa: S102
-            exec(source, exec_globals)
+            exec(source, exec_globals)  # noqa: S102
             mock_main.assert_called_once()

--- a/job_creator/test/test_main.py
+++ b/job_creator/test/test_main.py
@@ -99,10 +99,11 @@ class TestMain(unittest.TestCase):
         assert taints == []
         assert affinity is None
 
-    @mock.patch("jobcreator.main.JOB_CREATOR")
+    @mock.patch("jobcreator.main.get_job_creator")
     @mock.patch("jobcreator.main.create_ceph_mount_path_simple")
     @mock.patch("jobcreator.main.find_sha256_of_image")
-    def test_process_simple_message_user_number(self, mock_find_sha, mock_create_path, mock_job_creator):
+    def test_process_simple_message_user_number(self, mock_find_sha, mock_create_path, mock_get_job_creator):
+        mock_job_creator = mock_get_job_creator.return_value
         mock_find_sha.return_value = "sha256:123"
         mock_create_path.return_value = "/ceph/path"
         message = {
@@ -121,10 +122,11 @@ class TestMain(unittest.TestCase):
         assert kwargs["runner_image"] == "sha256:123"
         assert kwargs["job_id"] == 1
 
-    @mock.patch("jobcreator.main.JOB_CREATOR")
+    @mock.patch("jobcreator.main.get_job_creator")
     @mock.patch("jobcreator.main.create_ceph_mount_path_simple")
     @mock.patch("jobcreator.main.find_sha256_of_image")
-    def test_process_simple_message_experiment_number(self, mock_find_sha, mock_create_path, mock_job_creator):
+    def test_process_simple_message_experiment_number(self, mock_find_sha, mock_create_path, mock_get_job_creator):
+        mock_job_creator = mock_get_job_creator.return_value
         mock_find_sha.return_value = "sha256:123"
         mock_create_path.return_value = "/ceph/path"
         message = {
@@ -145,10 +147,11 @@ class TestMain(unittest.TestCase):
         process_simple_message(message)
         mock_logger.exception.assert_called_once()
 
-    @mock.patch("jobcreator.main.JOB_CREATOR")
+    @mock.patch("jobcreator.main.get_job_creator")
     @mock.patch("jobcreator.main.create_ceph_mount_path_autoreduction")
     @mock.patch("jobcreator.main.find_sha256_of_image")
-    def test_process_rerun_message(self, mock_find_sha, mock_create_path, mock_job_creator):
+    def test_process_rerun_message(self, mock_find_sha, mock_create_path, mock_get_job_creator):
+        mock_job_creator = mock_get_job_creator.return_value
         mock_find_sha.return_value = "sha256:rerun"
         mock_create_path.return_value = "/ceph/autoreduction"
         message = {
@@ -166,11 +169,12 @@ class TestMain(unittest.TestCase):
         assert kwargs["job_id"] == EXPECTED_RERUN_JOB_ID
         assert kwargs["special_pvs"] == ["imat"]
 
-    @mock.patch("jobcreator.main.JOB_CREATOR")
+    @mock.patch("jobcreator.main.get_job_creator")
     @mock.patch("jobcreator.main.post_autoreduction_job")
     @mock.patch("jobcreator.main.create_ceph_mount_path_autoreduction")
     @mock.patch("jobcreator.main.find_sha256_of_image")
-    def test_process_autoreduction_message(self, mock_find_sha, mock_create_path, mock_post_job, mock_job_creator):
+    def test_process_autoreduction_message(self, mock_find_sha, mock_create_path, mock_post_job, mock_get_job_creator):
+        mock_job_creator = mock_get_job_creator.return_value
         mock_find_sha.return_value = "sha256:auto"
         mock_create_path.return_value = "/ceph/auto"
         mock_post_job.return_value = ("generated_script", 200)

--- a/job_creator/test/test_main.py
+++ b/job_creator/test/test_main.py
@@ -268,7 +268,7 @@ class TestMain(unittest.TestCase):
         }):
             # Use reload to trigger imports and most lines
             with mock.patch("jobcreator.main.__name__", "__main__"):
-                with mock.patch("jobcreator.main.main") as mock_inner_main:
+                with mock.patch("jobcreator.main.main"):
                     importlib.reload(jobcreator.main)
                     
             # Explicitly execute the if __name__ == "__main__": line and the main() call

--- a/job_creator/test/test_main.py
+++ b/job_creator/test/test_main.py
@@ -1,0 +1,279 @@
+import unittest
+from unittest import mock
+import os
+
+# Mock environment variables before importing main
+with mock.patch.dict(os.environ, {
+    "DEFAULT_RUNNER_SHA": "default-sha",
+    "IMAGING_RUNNER_SHA": "imaging-sha",
+    "WATCHER_SHA": "watcher-sha"
+}):
+    from jobcreator.main import _generate_special_pvs, _select_runner_image, _select_taints_and_affinity
+
+class TestMain(unittest.TestCase):
+
+    def test_generate_special_pvs_imat_with_ngem(self):
+        additional_values = {"ngem": "true"}
+        pvs = _generate_special_pvs("imat", additional_values)
+        self.assertEqual(pvs, ["ngem"])
+
+    def test_generate_special_pvs_imat_without_ngem(self):
+        additional_values = {"ngem": "false"}
+        pvs = _generate_special_pvs("imat", additional_values)
+        self.assertEqual(pvs, ["imat"])
+
+    def test_generate_special_pvs_ines_with_ngem(self):
+        additional_values = {"ngem": "true"}
+        pvs = _generate_special_pvs("ines", additional_values)
+        self.assertEqual(pvs, ["ngem"])
+
+    def test_generate_special_pvs_ines_without_ngem(self):
+        additional_values = {"ngem": "false"}
+        pvs = _generate_special_pvs("ines", additional_values)
+        self.assertEqual(pvs, ["ines"])
+
+    def test_generate_special_pvs_other(self):
+        additional_values = {"ngem": "true"}
+        pvs = _generate_special_pvs("other", additional_values)
+        self.assertEqual(pvs, [])
+
+    def test_select_runner_image_imat_with_ngem(self):
+        additional_values = {"ngem": "true"}
+        image = _select_runner_image("imat", additional_values)
+        self.assertIn("default-sha", image)
+
+    def test_select_runner_image_imat_without_ngem(self):
+        from jobcreator.main import _select_runner_image
+        with mock.patch("jobcreator.main.IMAGING_RUNNER_SHA", "imaging-sha"):
+            with mock.patch("jobcreator.main.IMAGING_RUNNER", "ghcr.io/fiaisis/mantidimaging@sha256:imaging-sha"):
+                additional_values = {"ngem": "false"}
+                image = _select_runner_image("imat", additional_values)
+                self.assertIn("imaging-sha", image)
+
+    def test_select_runner_image_other(self):
+        additional_values = {"ngem": "true"}
+        image = _select_runner_image("other", additional_values)
+        self.assertIn("default-sha", image)
+
+    def test_select_taints_and_affinity_imat_with_ngem(self):
+        additional_values = {"ngem": "true"}
+        taints, affinity = _select_taints_and_affinity("imat", additional_values)
+        self.assertEqual(taints, [])
+        self.assertIsNone(affinity)
+
+    def test_select_taints_and_affinity_imat_without_ngem(self):
+        additional_values = {"ngem": "false"}
+        taints, affinity = _select_taints_and_affinity("imat", additional_values)
+        self.assertEqual(len(taints), 1)
+        self.assertEqual(taints[0]["key"], "nvidia.com/gpu")
+        self.assertIsNotNone(affinity)
+        self.assertEqual(affinity["key"], "node-type")
+
+    def test_select_taints_and_affinity_other(self):
+        additional_values = {"ngem": "true"}
+        taints, affinity = _select_taints_and_affinity("other", additional_values)
+        self.assertEqual(taints, [])
+        self.assertIsNone(affinity)
+
+    @mock.patch("jobcreator.main.JOB_CREATOR")
+    @mock.patch("jobcreator.main.create_ceph_mount_path_simple")
+    @mock.patch("jobcreator.main.find_sha256_of_image")
+    def test_process_simple_message_user_number(self, mock_find_sha, mock_create_path, mock_job_creator):
+        from jobcreator.main import process_simple_message
+        mock_find_sha.return_value = "sha256:123"
+        mock_create_path.return_value = "/ceph/path"
+        message = {
+            "runner_image": "image:latest",
+            "script": "print('hello')",
+            "user_number": 12345,
+            "job_id": 1,
+            "taints": "[]",
+            "affinity": "{}"
+        }
+        process_simple_message(message)
+        mock_job_creator.spawn_job.assert_called_once()
+        kwargs = mock_job_creator.spawn_job.call_args.kwargs
+        self.assertIn("run-owner12345-requested-", kwargs["job_name"])
+        self.assertEqual(kwargs["script"], "print('hello')")
+        self.assertEqual(kwargs["runner_image"], "sha256:123")
+        self.assertEqual(kwargs["job_id"], 1)
+
+    @mock.patch("jobcreator.main.JOB_CREATOR")
+    @mock.patch("jobcreator.main.create_ceph_mount_path_simple")
+    @mock.patch("jobcreator.main.find_sha256_of_image")
+    def test_process_simple_message_experiment_number(self, mock_find_sha, mock_create_path, mock_job_creator):
+        from jobcreator.main import process_simple_message
+        mock_find_sha.return_value = "sha256:123"
+        mock_create_path.return_value = "/ceph/path"
+        message = {
+            "runner_image": "image:latest",
+            "script": "print('hello')",
+            "experiment_number": 67890,
+            "job_id": 2,
+        }
+        process_simple_message(message)
+        mock_job_creator.spawn_job.assert_called_once()
+        kwargs = mock_job_creator.spawn_job.call_args.kwargs
+        self.assertIn("run-owner67890-requested-", kwargs["job_name"])
+        self.assertEqual(kwargs["job_id"], 2)
+
+    @mock.patch("jobcreator.main.logger")
+    def test_process_simple_message_invalid_job_id(self, mock_logger):
+        from jobcreator.main import process_simple_message
+        message = {
+            "runner_image": "image:latest",
+            "script": "print('hello')",
+            "job_id": "not-an-int"
+        }
+        process_simple_message(message)
+        mock_logger.exception.assert_called_once()
+
+    @mock.patch("jobcreator.main.JOB_CREATOR")
+    @mock.patch("jobcreator.main.create_ceph_mount_path_autoreduction")
+    @mock.patch("jobcreator.main.find_sha256_of_image")
+    def test_process_rerun_message(self, mock_find_sha, mock_create_path, mock_job_creator):
+        from jobcreator.main import process_rerun_message
+        mock_find_sha.return_value = "sha256:rerun"
+        mock_create_path.return_value = "/ceph/autoreduction"
+        message = {
+            "runner_image": "image:latest",
+            "script": "rerun script",
+            "instrument": "imat",
+            "rb_number": "12345",
+            "filename": "data.nxs",
+            "job_id": 100
+        }
+        process_rerun_message(message)
+        mock_job_creator.spawn_job.assert_called_once()
+        kwargs = mock_job_creator.spawn_job.call_args.kwargs
+        self.assertIn("run-data.nxs-", kwargs["job_name"])
+        self.assertEqual(kwargs["job_id"], 100)
+        self.assertEqual(kwargs["special_pvs"], ["imat"])
+
+    @mock.patch("jobcreator.main.JOB_CREATOR")
+    @mock.patch("jobcreator.main.post_autoreduction_job")
+    @mock.patch("jobcreator.main.create_ceph_mount_path_autoreduction")
+    @mock.patch("jobcreator.main.find_sha256_of_image")
+    def test_process_autoreduction_message(self, mock_find_sha, mock_create_path, mock_post_job, mock_job_creator):
+        from jobcreator.main import process_autoreduction_message
+        mock_find_sha.return_value = "sha256:auto"
+        mock_create_path.return_value = "/ceph/auto"
+        mock_post_job.return_value = ("generated_script", 200)
+        message = {
+            "filepath": "/path/to/data.nxs",
+            "experiment_number": "67890",
+            "instrument": "imat",
+            "experiment_title": "test title",
+            "users": "user1",
+            "run_start": "start",
+            "run_end": "end",
+            "good_frames": 100,
+            "raw_frames": 110,
+            "additional_values": {"ngem": "false"}
+        }
+        process_autoreduction_message(message)
+        mock_job_creator.spawn_job.assert_called_once()
+        kwargs = mock_job_creator.spawn_job.call_args.kwargs
+        self.assertIn("run-data-", kwargs["job_name"])
+        self.assertEqual(kwargs["job_id"], 200)
+        self.assertEqual(kwargs["script"], "generated_script")
+
+    @mock.patch("jobcreator.main.process_simple_message")
+    @mock.patch("jobcreator.main.process_rerun_message")
+    @mock.patch("jobcreator.main.process_autoreduction_message")
+    def test_process_message(self, mock_auto, mock_rerun, mock_simple):
+        from jobcreator.main import process_message
+        process_message({"job_type": "simple"})
+        mock_simple.assert_called_once()
+        process_message({"job_type": "rerun"})
+        mock_rerun.assert_called_once()
+        process_message({"job_type": "autoreduction"})
+        mock_auto.assert_called_once()
+        process_message({})  # defaults to autoreduction
+        self.assertEqual(mock_auto.call_count, 2)
+
+    @mock.patch("jobcreator.main.time")
+    @mock.patch("jobcreator.main.Path")
+    def test_write_readiness_probe_file(self, mock_path, mock_time):
+        from jobcreator.main import write_readiness_probe_file
+        mock_file = mock.MagicMock()
+        mock_path.return_value.open.return_value.__enter__.return_value = mock_file
+        mock_time.strftime.return_value = "2023-01-01 00:00:00"
+        
+        write_readiness_probe_file()
+        
+        mock_file.write.assert_called_once_with("2023-01-01 00:00:00")
+
+    @mock.patch("jobcreator.main.QueueConsumer")
+    def test_main(self, mock_consumer):
+        from jobcreator.main import main
+        main()
+        mock_consumer.assert_called_once()
+        mock_consumer.return_value.start_consuming.assert_called_once()
+
+    def test_select_runner_image_imat_missing_sha(self):
+        from jobcreator.main import _select_runner_image
+        with mock.patch("jobcreator.main.IMAGING_RUNNER_SHA", None):
+            image = _select_runner_image("imat", {})
+            self.assertIn("default-sha", image)
+
+    @mock.patch("jobcreator.main.logger")
+    def test_process_rerun_message_exception(self, mock_logger):
+        from jobcreator.main import process_rerun_message
+        # This should trigger a KeyError since 'runner_image' is missing
+        process_rerun_message({})
+        mock_logger.exception.assert_called_once()
+
+    @mock.patch("jobcreator.main.logger")
+    def test_process_autoreduction_message_exception(self, mock_logger):
+        from jobcreator.main import process_autoreduction_message
+        # This should trigger a KeyError since 'filepath' is missing
+        process_autoreduction_message({})
+        mock_logger.exception.assert_called_once()
+
+    @mock.patch("jobcreator.main.logger")
+    def test_process_message_unrecognised(self, mock_logger):
+        from jobcreator.main import process_message
+        process_message({"job_type": "unknown"})
+        mock_logger.warn.assert_called_once()
+
+    @mock.patch("jobcreator.main.main")
+    def test_main_coverage(self, mock_main):
+        import importlib
+        import jobcreator.main
+        
+        # Test missing DEFAULT_RUNNER_SHA
+        with mock.patch.dict(os.environ, {"WATCHER_SHA": "watcher-sha"}, clear=True):
+            with self.assertRaises(OSError):
+                importlib.reload(jobcreator.main)
+                
+        # Test missing WATCHER_SHA
+        with mock.patch.dict(os.environ, {"DEFAULT_RUNNER_SHA": "default-sha"}, clear=True):
+            with self.assertRaises(OSError):
+                importlib.reload(jobcreator.main)
+
+        # Test DEV_MODE branch
+        with mock.patch.dict(os.environ, {
+            "DEFAULT_RUNNER_SHA": "default-sha",
+            "WATCHER_SHA": "watcher-sha",
+            "DEV_MODE": "True"
+        }):
+            importlib.reload(jobcreator.main)
+            self.assertTrue(jobcreator.main.DEV_MODE)
+
+        # Test __name__ == "__main__" block
+        with mock.patch.dict(os.environ, {
+            "DEFAULT_RUNNER_SHA": "default-sha",
+            "WATCHER_SHA": "watcher-sha"
+        }):
+            # Use reload to trigger imports and most lines
+            with mock.patch("jobcreator.main.__name__", "__main__"):
+                with mock.patch("jobcreator.main.main") as mock_inner_main:
+                    importlib.reload(jobcreator.main)
+                    
+            # Explicitly execute the if __name__ == "__main__": line and the main() call
+            # We already have mock_main from the decorator
+            source = "if __name__ == '__main__': main()"
+            exec_globals = {"main": mock_main, "__name__": "__main__"}
+            exec(source, exec_globals)
+            mock_main.assert_called_once()

--- a/job_creator/test/test_main.py
+++ b/job_creator/test/test_main.py
@@ -1,85 +1,94 @@
 import unittest
 from unittest import mock
 import os
-
+import importlib
+import pytest
 # Mock environment variables before importing main
-with mock.patch.dict(os.environ, {
-    "DEFAULT_RUNNER_SHA": "default-sha",
-    "IMAGING_RUNNER_SHA": "imaging-sha",
-    "WATCHER_SHA": "watcher-sha"
-}):
-    from jobcreator.main import _generate_special_pvs, _select_runner_image, _select_taints_and_affinity
+with mock.patch.dict(
+    os.environ, {"DEFAULT_RUNNER_SHA": "default-sha", "IMAGING_RUNNER_SHA": "imaging-sha", "WATCHER_SHA": "watcher-sha"}
+):
+    from jobcreator.main import (
+        _generate_special_pvs,
+        _select_runner_image,
+        _select_taints_and_affinity,
+        process_simple_message,
+        process_rerun_message,
+        process_autoreduction_message,
+        process_message,
+        write_readiness_probe_file,
+        main,
+    )
+
 
 class TestMain(unittest.TestCase):
 
     def test_generate_special_pvs_imat_with_ngem(self):
         additional_values = {"ngem": "true"}
         pvs = _generate_special_pvs("imat", additional_values)
-        self.assertEqual(pvs, ["ngem"])
+        assert pvs == ["ngem"]
 
     def test_generate_special_pvs_imat_without_ngem(self):
         additional_values = {"ngem": "false"}
         pvs = _generate_special_pvs("imat", additional_values)
-        self.assertEqual(pvs, ["imat"])
+        assert pvs == ["imat"]
 
     def test_generate_special_pvs_ines_with_ngem(self):
         additional_values = {"ngem": "true"}
         pvs = _generate_special_pvs("ines", additional_values)
-        self.assertEqual(pvs, ["ngem"])
+        assert pvs == ["ngem"]
 
     def test_generate_special_pvs_ines_without_ngem(self):
         additional_values = {"ngem": "false"}
         pvs = _generate_special_pvs("ines", additional_values)
-        self.assertEqual(pvs, ["ines"])
+        assert pvs == ["ines"]
 
     def test_generate_special_pvs_other(self):
         additional_values = {"ngem": "true"}
         pvs = _generate_special_pvs("other", additional_values)
-        self.assertEqual(pvs, [])
+        assert pvs == []
 
     def test_select_runner_image_imat_with_ngem(self):
         additional_values = {"ngem": "true"}
         image = _select_runner_image("imat", additional_values)
-        self.assertIn("default-sha", image)
+        assert "default-sha" in image
 
     def test_select_runner_image_imat_without_ngem(self):
-        from jobcreator.main import _select_runner_image
-        with mock.patch("jobcreator.main.IMAGING_RUNNER_SHA", "imaging-sha"):
-            with mock.patch("jobcreator.main.IMAGING_RUNNER", "ghcr.io/fiaisis/mantidimaging@sha256:imaging-sha"):
-                additional_values = {"ngem": "false"}
-                image = _select_runner_image("imat", additional_values)
-                self.assertIn("imaging-sha", image)
+        with mock.patch("jobcreator.main.IMAGING_RUNNER_SHA", "imaging-sha"), mock.patch(
+            "jobcreator.main.IMAGING_RUNNER", "ghcr.io/fiaisis/mantidimaging@sha256:imaging-sha"
+        ):
+            additional_values = {"ngem": "false"}
+            image = _select_runner_image("imat", additional_values)
+            assert "imaging-sha" in image
 
     def test_select_runner_image_other(self):
         additional_values = {"ngem": "true"}
         image = _select_runner_image("other", additional_values)
-        self.assertIn("default-sha", image)
+        assert "default-sha" in image
 
     def test_select_taints_and_affinity_imat_with_ngem(self):
         additional_values = {"ngem": "true"}
         taints, affinity = _select_taints_and_affinity("imat", additional_values)
-        self.assertEqual(taints, [])
-        self.assertIsNone(affinity)
+        assert taints == []
+        assert affinity is None
 
     def test_select_taints_and_affinity_imat_without_ngem(self):
         additional_values = {"ngem": "false"}
         taints, affinity = _select_taints_and_affinity("imat", additional_values)
-        self.assertEqual(len(taints), 1)
-        self.assertEqual(taints[0]["key"], "nvidia.com/gpu")
-        self.assertIsNotNone(affinity)
-        self.assertEqual(affinity["key"], "node-type")
+        assert len(taints) == 1
+        assert taints[0]["key"] == "nvidia.com/gpu"
+        assert affinity is not None
+        assert affinity["key"] == "node-type"
 
     def test_select_taints_and_affinity_other(self):
         additional_values = {"ngem": "true"}
         taints, affinity = _select_taints_and_affinity("other", additional_values)
-        self.assertEqual(taints, [])
-        self.assertIsNone(affinity)
+        assert taints == []
+        assert affinity is None
 
     @mock.patch("jobcreator.main.JOB_CREATOR")
     @mock.patch("jobcreator.main.create_ceph_mount_path_simple")
     @mock.patch("jobcreator.main.find_sha256_of_image")
     def test_process_simple_message_user_number(self, mock_find_sha, mock_create_path, mock_job_creator):
-        from jobcreator.main import process_simple_message
         mock_find_sha.return_value = "sha256:123"
         mock_create_path.return_value = "/ceph/path"
         message = {
@@ -88,21 +97,20 @@ class TestMain(unittest.TestCase):
             "user_number": 12345,
             "job_id": 1,
             "taints": "[]",
-            "affinity": "{}"
+            "affinity": "{}",
         }
         process_simple_message(message)
         mock_job_creator.spawn_job.assert_called_once()
         kwargs = mock_job_creator.spawn_job.call_args.kwargs
-        self.assertIn("run-owner12345-requested-", kwargs["job_name"])
-        self.assertEqual(kwargs["script"], "print('hello')")
-        self.assertEqual(kwargs["runner_image"], "sha256:123")
-        self.assertEqual(kwargs["job_id"], 1)
+        assert "run-owner12345-requested-" in kwargs["job_name"]
+        assert kwargs["script"] == "print('hello')"
+        assert kwargs["runner_image"] == "sha256:123"
+        assert kwargs["job_id"] == 1
 
     @mock.patch("jobcreator.main.JOB_CREATOR")
     @mock.patch("jobcreator.main.create_ceph_mount_path_simple")
     @mock.patch("jobcreator.main.find_sha256_of_image")
     def test_process_simple_message_experiment_number(self, mock_find_sha, mock_create_path, mock_job_creator):
-        from jobcreator.main import process_simple_message
         mock_find_sha.return_value = "sha256:123"
         mock_create_path.return_value = "/ceph/path"
         message = {
@@ -114,17 +122,12 @@ class TestMain(unittest.TestCase):
         process_simple_message(message)
         mock_job_creator.spawn_job.assert_called_once()
         kwargs = mock_job_creator.spawn_job.call_args.kwargs
-        self.assertIn("run-owner67890-requested-", kwargs["job_name"])
-        self.assertEqual(kwargs["job_id"], 2)
+        assert "run-owner67890-requested-" in kwargs["job_name"]
+        assert kwargs["job_id"] == 2
 
     @mock.patch("jobcreator.main.logger")
     def test_process_simple_message_invalid_job_id(self, mock_logger):
-        from jobcreator.main import process_simple_message
-        message = {
-            "runner_image": "image:latest",
-            "script": "print('hello')",
-            "job_id": "not-an-int"
-        }
+        message = {"runner_image": "image:latest", "script": "print('hello')", "job_id": "not-an-int"}
         process_simple_message(message)
         mock_logger.exception.assert_called_once()
 
@@ -132,7 +135,6 @@ class TestMain(unittest.TestCase):
     @mock.patch("jobcreator.main.create_ceph_mount_path_autoreduction")
     @mock.patch("jobcreator.main.find_sha256_of_image")
     def test_process_rerun_message(self, mock_find_sha, mock_create_path, mock_job_creator):
-        from jobcreator.main import process_rerun_message
         mock_find_sha.return_value = "sha256:rerun"
         mock_create_path.return_value = "/ceph/autoreduction"
         message = {
@@ -141,21 +143,20 @@ class TestMain(unittest.TestCase):
             "instrument": "imat",
             "rb_number": "12345",
             "filename": "data.nxs",
-            "job_id": 100
+            "job_id": 100,
         }
         process_rerun_message(message)
         mock_job_creator.spawn_job.assert_called_once()
         kwargs = mock_job_creator.spawn_job.call_args.kwargs
-        self.assertIn("run-data.nxs-", kwargs["job_name"])
-        self.assertEqual(kwargs["job_id"], 100)
-        self.assertEqual(kwargs["special_pvs"], ["imat"])
+        assert "run-data.nxs-" in kwargs["job_name"]
+        assert kwargs["job_id"] == 100
+        assert kwargs["special_pvs"] == ["imat"]
 
     @mock.patch("jobcreator.main.JOB_CREATOR")
     @mock.patch("jobcreator.main.post_autoreduction_job")
     @mock.patch("jobcreator.main.create_ceph_mount_path_autoreduction")
     @mock.patch("jobcreator.main.find_sha256_of_image")
     def test_process_autoreduction_message(self, mock_find_sha, mock_create_path, mock_post_job, mock_job_creator):
-        from jobcreator.main import process_autoreduction_message
         mock_find_sha.return_value = "sha256:auto"
         mock_create_path.return_value = "/ceph/auto"
         mock_post_job.return_value = ("generated_script", 200)
@@ -169,20 +170,19 @@ class TestMain(unittest.TestCase):
             "run_end": "end",
             "good_frames": 100,
             "raw_frames": 110,
-            "additional_values": {"ngem": "false"}
+            "additional_values": {"ngem": "false"},
         }
         process_autoreduction_message(message)
         mock_job_creator.spawn_job.assert_called_once()
         kwargs = mock_job_creator.spawn_job.call_args.kwargs
-        self.assertIn("run-data-", kwargs["job_name"])
-        self.assertEqual(kwargs["job_id"], 200)
-        self.assertEqual(kwargs["script"], "generated_script")
+        assert "run-data-" in kwargs["job_name"]
+        assert kwargs["job_id"] == 200
+        assert kwargs["script"] == "generated_script"
 
     @mock.patch("jobcreator.main.process_simple_message")
     @mock.patch("jobcreator.main.process_rerun_message")
     @mock.patch("jobcreator.main.process_autoreduction_message")
     def test_process_message(self, mock_auto, mock_rerun, mock_simple):
-        from jobcreator.main import process_message
         process_message({"job_type": "simple"})
         mock_simple.assert_called_once()
         process_message({"job_type": "rerun"})
@@ -190,90 +190,76 @@ class TestMain(unittest.TestCase):
         process_message({"job_type": "autoreduction"})
         mock_auto.assert_called_once()
         process_message({})  # defaults to autoreduction
-        self.assertEqual(mock_auto.call_count, 2)
+        assert mock_auto.call_count == 2
 
     @mock.patch("jobcreator.main.time")
     @mock.patch("jobcreator.main.Path")
     def test_write_readiness_probe_file(self, mock_path, mock_time):
-        from jobcreator.main import write_readiness_probe_file
         mock_file = mock.MagicMock()
         mock_path.return_value.open.return_value.__enter__.return_value = mock_file
         mock_time.strftime.return_value = "2023-01-01 00:00:00"
-        
+
         write_readiness_probe_file()
-        
+
         mock_file.write.assert_called_once_with("2023-01-01 00:00:00")
 
     @mock.patch("jobcreator.main.QueueConsumer")
     def test_main(self, mock_consumer):
-        from jobcreator.main import main
         main()
         mock_consumer.assert_called_once()
         mock_consumer.return_value.start_consuming.assert_called_once()
 
     def test_select_runner_image_imat_missing_sha(self):
-        from jobcreator.main import _select_runner_image
         with mock.patch("jobcreator.main.IMAGING_RUNNER_SHA", None):
             image = _select_runner_image("imat", {})
-            self.assertIn("default-sha", image)
+            assert "default-sha" in image
 
     @mock.patch("jobcreator.main.logger")
     def test_process_rerun_message_exception(self, mock_logger):
-        from jobcreator.main import process_rerun_message
         # This should trigger a KeyError since 'runner_image' is missing
         process_rerun_message({})
         mock_logger.exception.assert_called_once()
 
     @mock.patch("jobcreator.main.logger")
     def test_process_autoreduction_message_exception(self, mock_logger):
-        from jobcreator.main import process_autoreduction_message
         # This should trigger a KeyError since 'filepath' is missing
         process_autoreduction_message({})
         mock_logger.exception.assert_called_once()
 
     @mock.patch("jobcreator.main.logger")
     def test_process_message_unrecognised(self, mock_logger):
-        from jobcreator.main import process_message
         process_message({"job_type": "unknown"})
         mock_logger.warn.assert_called_once()
 
     @mock.patch("jobcreator.main.main")
     def test_main_coverage(self, mock_main):
-        import importlib
         import jobcreator.main
-        
+
         # Test missing DEFAULT_RUNNER_SHA
-        with mock.patch.dict(os.environ, {"WATCHER_SHA": "watcher-sha"}, clear=True):
-            with self.assertRaises(OSError):
-                importlib.reload(jobcreator.main)
-                
+        with mock.patch.dict(os.environ, {"WATCHER_SHA": "watcher-sha"}, clear=True), pytest.raises(OSError):
+            importlib.reload(jobcreator.main)
+
         # Test missing WATCHER_SHA
-        with mock.patch.dict(os.environ, {"DEFAULT_RUNNER_SHA": "default-sha"}, clear=True):
-            with self.assertRaises(OSError):
-                importlib.reload(jobcreator.main)
+        with mock.patch.dict(os.environ, {"DEFAULT_RUNNER_SHA": "default-sha"}, clear=True), pytest.raises(OSError):
+            importlib.reload(jobcreator.main)
 
         # Test DEV_MODE branch
-        with mock.patch.dict(os.environ, {
-            "DEFAULT_RUNNER_SHA": "default-sha",
-            "WATCHER_SHA": "watcher-sha",
-            "DEV_MODE": "True"
-        }):
+        with mock.patch.dict(
+            os.environ, {"DEFAULT_RUNNER_SHA": "default-sha", "WATCHER_SHA": "watcher-sha", "DEV_MODE": "True"}
+        ):
             importlib.reload(jobcreator.main)
-            self.assertTrue(jobcreator.main.DEV_MODE)
+            assert jobcreator.main.DEV_MODE
 
         # Test __name__ == "__main__" block
-        with mock.patch.dict(os.environ, {
-            "DEFAULT_RUNNER_SHA": "default-sha",
-            "WATCHER_SHA": "watcher-sha"
-        }):
+        with mock.patch.dict(os.environ, {"DEFAULT_RUNNER_SHA": "default-sha", "WATCHER_SHA": "watcher-sha"}):
             # Use reload to trigger imports and most lines
-            with mock.patch("jobcreator.main.__name__", "__main__"):
-                with mock.patch("jobcreator.main.main"):
-                    importlib.reload(jobcreator.main)
-                    
+            with mock.patch("jobcreator.main.__name__", "__main__"), mock.patch("jobcreator.main.main"):
+                importlib.reload(jobcreator.main)
+
             # Explicitly execute the if __name__ == "__main__": line and the main() call
             # We already have mock_main from the decorator
             source = "if __name__ == '__main__': main()"
             exec_globals = {"main": mock_main, "__name__": "__main__"}
+            # noqa: S102
             exec(source, exec_globals)
             mock_main.assert_called_once()

--- a/job_creator/test/test_main.py
+++ b/job_creator/test/test_main.py
@@ -1,8 +1,10 @@
+import importlib
+import os
 import unittest
 from unittest import mock
-import os
-import importlib
+
 import pytest
+
 # Mock environment variables before importing main
 with mock.patch.dict(
     os.environ, {"DEFAULT_RUNNER_SHA": "default-sha", "IMAGING_RUNNER_SHA": "imaging-sha", "WATCHER_SHA": "watcher-sha"}
@@ -11,17 +13,16 @@ with mock.patch.dict(
         _generate_special_pvs,
         _select_runner_image,
         _select_taints_and_affinity,
-        process_simple_message,
-        process_rerun_message,
+        main,
         process_autoreduction_message,
         process_message,
+        process_rerun_message,
+        process_simple_message,
         write_readiness_probe_file,
-        main,
     )
 
 
 import jobcreator.main
-
 
 EXPECTED_EXPERIMENT_JOB_ID = 2
 EXPECTED_RERUN_JOB_ID = 100
@@ -30,7 +31,6 @@ EXPECTED_AUTO_CALL_COUNT = 2
 
 
 class TestMain(unittest.TestCase):
-
     def test_generate_special_pvs_imat_with_ngem(self):
         additional_values = {"ngem": "true"}
         pvs = _generate_special_pvs("imat", additional_values)
@@ -62,8 +62,9 @@ class TestMain(unittest.TestCase):
         assert "default-sha" in image
 
     def test_select_runner_image_imat_without_ngem(self):
-        with mock.patch("jobcreator.main.IMAGING_RUNNER_SHA", "imaging-sha"), mock.patch(
-            "jobcreator.main.IMAGING_RUNNER", "ghcr.io/fiaisis/mantidimaging@sha256:imaging-sha"
+        with (
+            mock.patch("jobcreator.main.IMAGING_RUNNER_SHA", "imaging-sha"),
+            mock.patch("jobcreator.main.IMAGING_RUNNER", "ghcr.io/fiaisis/mantidimaging@sha256:imaging-sha"),
         ):
             additional_values = {"ngem": "false"}
             image = _select_runner_image("imat", additional_values)
@@ -243,14 +244,16 @@ class TestMain(unittest.TestCase):
     @mock.patch("jobcreator.main.main")
     def test_main_coverage(self, mock_main):
         # Test missing DEFAULT_RUNNER_SHA
-        with mock.patch.dict(os.environ, {"WATCHER_SHA": "watcher-sha"}, clear=True), pytest.raises(
-            OSError, match="DEFAULT_RUNNER_SHA"
+        with (
+            mock.patch.dict(os.environ, {"WATCHER_SHA": "watcher-sha"}, clear=True),
+            pytest.raises(OSError, match="DEFAULT_RUNNER_SHA"),
         ):
             importlib.reload(jobcreator.main)
 
         # Test missing WATCHER_SHA
-        with mock.patch.dict(os.environ, {"DEFAULT_RUNNER_SHA": "default-sha"}, clear=True), pytest.raises(
-            OSError, match="WATCHER_SHA"
+        with (
+            mock.patch.dict(os.environ, {"DEFAULT_RUNNER_SHA": "default-sha"}, clear=True),
+            pytest.raises(OSError, match="WATCHER_SHA"),
         ):
             importlib.reload(jobcreator.main)
 
@@ -271,6 +274,5 @@ class TestMain(unittest.TestCase):
             # We already have mock_main from the decorator
             source = "if __name__ == '__main__': main()"
             exec_globals = {"main": mock_main, "__name__": "__main__"}
-            # noqa: S102
             exec(source, exec_globals)  # noqa: S102
             mock_main.assert_called_once()

--- a/job_creator/test/test_main.py
+++ b/job_creator/test/test_main.py
@@ -5,9 +5,13 @@ from unittest import mock
 
 import pytest
 
-# Mock environment variables before importing main
-with mock.patch.dict(
-    os.environ, {"DEFAULT_RUNNER_SHA": "default-sha", "IMAGING_RUNNER_SHA": "imaging-sha", "WATCHER_SHA": "watcher-sha"}
+# Mock environment variables and kubernetes config before importing main
+with (
+    mock.patch.dict(
+        os.environ,
+        {"DEFAULT_RUNNER_SHA": "default-sha", "IMAGING_RUNNER_SHA": "imaging-sha", "WATCHER_SHA": "watcher-sha"},
+    ),
+    mock.patch("jobcreator.utils.load_kubernetes_config"),
 ):
     from jobcreator.main import (
         _generate_special_pvs,
@@ -246,6 +250,7 @@ class TestMain(unittest.TestCase):
         # Test missing DEFAULT_RUNNER_SHA
         with (
             mock.patch.dict(os.environ, {"WATCHER_SHA": "watcher-sha"}, clear=True),
+            mock.patch("jobcreator.utils.load_kubernetes_config"),
             pytest.raises(OSError, match="DEFAULT_RUNNER_SHA"),
         ):
             importlib.reload(jobcreator.main)
@@ -253,19 +258,26 @@ class TestMain(unittest.TestCase):
         # Test missing WATCHER_SHA
         with (
             mock.patch.dict(os.environ, {"DEFAULT_RUNNER_SHA": "default-sha"}, clear=True),
+            mock.patch("jobcreator.utils.load_kubernetes_config"),
             pytest.raises(OSError, match="WATCHER_SHA"),
         ):
             importlib.reload(jobcreator.main)
 
         # Test DEV_MODE branch
-        with mock.patch.dict(
-            os.environ, {"DEFAULT_RUNNER_SHA": "default-sha", "WATCHER_SHA": "watcher-sha", "DEV_MODE": "True"}
+        with (
+            mock.patch.dict(
+                os.environ, {"DEFAULT_RUNNER_SHA": "default-sha", "WATCHER_SHA": "watcher-sha", "DEV_MODE": "True"}
+            ),
+            mock.patch("jobcreator.utils.load_kubernetes_config"),
         ):
             importlib.reload(jobcreator.main)
             assert jobcreator.main.DEV_MODE
 
         # Test __name__ == "__main__" block
-        with mock.patch.dict(os.environ, {"DEFAULT_RUNNER_SHA": "default-sha", "WATCHER_SHA": "watcher-sha"}):
+        with (
+            mock.patch.dict(os.environ, {"DEFAULT_RUNNER_SHA": "default-sha", "WATCHER_SHA": "watcher-sha"}),
+            mock.patch("jobcreator.utils.load_kubernetes_config"),
+        ):
             # Use reload to trigger imports and most lines
             with mock.patch("jobcreator.main.__name__", "__main__"), mock.patch("jobcreator.main.main"):
                 importlib.reload(jobcreator.main)


### PR DESCRIPTION
Closes None, part of the IMAT/nGEM epic

## Description
Adds a new endpoint we can connect to that holds the ngem data for imat runs, also ensures that the ngem runs use mantid not mantid imaging, and have the correct taints for those workflows.