### PR TITLE
Add nvidia runtimeclass to GPU needed pods

### DIFF
--- a/job_creator/jobcreator/job_creator.py
+++ b/job_creator/jobcreator/job_creator.py
@@ -402,12 +402,22 @@ class JobCreator:
             )
             volumes_mounts.append(client.V1VolumeMount(name="dev-shm", mount_path="/dev/shm"))  # noqa: S108
 
+        # Decide whether this is a GPU workload. IMAT jobs run mantid imaging on GPU nodes and need
+        # the NVIDIA runtime + a GPU resource request so the GPU Operator injects the matching
+        # userspace driver libraries (libcuda.so.*) into the container.
+        gpu_job = "imat" in special_pvs
+
         main_container = client.V1Container(
             name=job_name,
             image=runner_image,
             args=[script],
             env=[client.V1EnvVar(name="PYTHONUNBUFFERED", value="1")],
             volume_mounts=volumes_mounts,
+            resources=client.V1ResourceRequirements(
+                limits={"nvidia.com/gpu": "1"},
+            )
+            if gpu_job
+            else None,
         )
 
         watcher_container = client.V1Container(
@@ -433,6 +443,7 @@ class JobCreator:
             restart_policy="Never",
             tolerations=tolerations,
             volumes=volumes,
+            runtime_class_name="nvidia" if gpu_job else None,
         )
 
         pod_metadata = client.V1ObjectMeta(

--- a/job_creator/test/test_job_creator.py
+++ b/job_creator/test/test_job_creator.py
@@ -331,6 +331,7 @@ def test_jobcreator_spawn_job_dev_mode_true(
         restart_policy="Never",
         tolerations=[],
         volumes=[client.V1Volume.return_value, client.V1Volume.return_value, client.V1Volume.return_value],
+        runtime_class_name=None,
     )
     assert (
         call(name="ceph-mount", persistent_volume_claim=client.V1PersistentVolumeClaimVolumeSource.return_value)
@@ -384,6 +385,7 @@ def test_jobcreator_spawn_job_dev_mode_true(
                 client.V1VolumeMount(name="ceph-mount", mount_path="/output"),
                 client.V1VolumeMount(name="extras-mount", mount_path="/extras"),
             ],
+            resources=None,
         )
         in client.V1Container.call_args_list
     )
@@ -519,6 +521,7 @@ def test_jobcreator_spawn_job_dev_mode_true_imat(
             client.V1Volume.return_value,
             client.V1Volume.return_value,
         ],
+        runtime_class_name="nvidia",
     )
     assert (
         call(name="ceph-mount", persistent_volume_claim=client.V1PersistentVolumeClaimVolumeSource.return_value)
@@ -587,6 +590,7 @@ def test_jobcreator_spawn_job_dev_mode_true_imat(
                 client.V1VolumeMount(name="imat-mount", mount_path="/imat"),
                 client.V1VolumeMount(name="dev-shm", mount_path="/dev/shm"),  # noqa: S108
             ],
+            resources=client.V1ResourceRequirements(limits={"nvidia.com/gpu": "1"}),
         )
         in client.V1Container.call_args_list
     )


### PR DESCRIPTION
Closes None, part of IMAT fixes

## Description
Ensures that jobs that use a GPU (just imat special pv related jobs atm) get the correct runtime class assigned so it uses the GPU drivers.