### PR TITLE
Add failed queue retries for jobcreator messages

### DIFF
--- a/job_creator/jobcreator/main.py
+++ b/job_creator/jobcreator/main.py
@@ -42,6 +42,7 @@ FIA_API_HOST = os.environ.get("FIA_API", "fia-api-service.fia.svc.cluster.local:
 FIA_API_API_KEY = os.environ.get("FIA_API_API_KEY", "")
 QUEUE_HOST = os.environ.get("QUEUE_HOST", "")
 QUEUE_NAME = os.environ.get("INGRESS_QUEUE_NAME", "")
+FAILURE_QUEUE_NAME = os.environ.get("FAILURE_QUEUE_NAME", "failed-scheduled-jobs")
 CONSUMER_USERNAME = os.environ.get("QUEUE_USER", "")
 CONSUMER_PASSWORD = os.environ.get("QUEUE_PASSWORD", "")
 REDUCE_USER_ID = os.environ.get("REDUCE_USER_ID", "")
@@ -166,8 +167,9 @@ def process_simple_message(message: dict[str, Any]) -> None:
             taints=taints,
             affinity=affinity,
         )
-    except Exception as exception:
-        logger.exception(exception)
+    except Exception:
+        logger.exception("Failed to process simple message")
+        raise
 
 
 def process_rerun_message(message: dict[str, Any]) -> None:
@@ -210,8 +212,9 @@ def process_rerun_message(message: dict[str, Any]) -> None:
             taints=taints,
             affinity=affinity,
         )
-    except Exception as exception:
-        logger.exception(exception)
+    except Exception:
+        logger.exception("Failed to process rerun message")
+        raise
 
 
 def process_autoreduction_message(message: dict[str, Any]) -> None:
@@ -273,8 +276,9 @@ def process_autoreduction_message(message: dict[str, Any]) -> None:
             taints=taints,
             affinity=affinity,
         )
-    except Exception as exception:
-        logger.exception(exception)
+    except Exception:
+        logger.exception("Failed to process autoreduction message")
+        raise
 
 
 def process_message(message: dict[str, Any]) -> None:
@@ -297,7 +301,7 @@ def process_message(message: dict[str, Any]) -> None:
             logger.info("Processing autoreduction message")
             process_autoreduction_message(message)
         case _:
-            logger.warn("message type not recognised, not starting job. Message: ", message)
+            raise ValueError(f"message type not recognised, not starting job. Message: {message}")
 
 
 def write_readiness_probe_file() -> None:
@@ -320,6 +324,7 @@ def main() -> None:
         username=CONSUMER_USERNAME,
         password=CONSUMER_PASSWORD,
         queue_name=QUEUE_NAME,
+        failure_queue_name=FAILURE_QUEUE_NAME,
     )
     consumer.start_consuming(write_readiness_probe_file)
 

--- a/job_creator/jobcreator/queue_consumer.py
+++ b/job_creator/jobcreator/queue_consumer.py
@@ -5,6 +5,7 @@ The module is aimed to consume from a station on Memphis using the create_statio
 import json
 import time
 from collections.abc import Callable
+from typing import Any
 
 from pika import BlockingConnection, ConnectionParameters, PlainCredentials  # type: ignore[import-untyped]
 
@@ -19,20 +20,38 @@ class QueueConsumer:
 
     def __init__(
         self,
-        message_callback: Callable[[dict[str, str]], None],
+        message_callback: Callable[[dict[str, Any]], None],
         queue_host: str,
         username: str,
         password: str,
         queue_name: str,
+        failure_queue_name: str,
     ) -> None:
         self.message_callback = message_callback
         self.queue_host = queue_host
         self.queue_name = queue_name
+        self.failure_queue_name = failure_queue_name
         credentials = PlainCredentials(username=username, password=password)
         self.connection_parameters = ConnectionParameters(queue_host, 5672, credentials=credentials)
-        self.connection = None
-        self.channel = None
+        self.connection: Any = None
+        self.channel: Any = None
+        self.failure_connection: Any = None
+        self.failure_channel: Any = None
         self.connect_to_broker()
+
+    def _declare_queue(self, channel: Any, queue_name: str) -> None:
+        channel.exchange_declare(
+            queue_name,
+            exchange_type="direct",
+            durable=True,
+        )
+        channel.queue_declare(
+            queue_name,
+            durable=True,
+            arguments={"x-queue-type": "quorum"},
+        )
+        channel.queue_bind(queue_name, queue_name, routing_key="")
+        channel.basic_qos(prefetch_count=1)
 
     def connect_to_broker(self) -> None:
         """
@@ -40,18 +59,12 @@ class QueueConsumer:
         :return: None
         """
         self.connection = BlockingConnection(self.connection_parameters)
-        self.channel = self.connection.channel()  # type: ignore[attr-defined]
-        self.channel.exchange_declare(  # type: ignore[attr-defined]
-            self.queue_name,
-            exchange_type="direct",
-            durable=True,
-        )
-        self.channel.queue_declare(  # type: ignore[attr-defined]
-            self.queue_name,
-            durable=True,
-            arguments={"x-queue-type": "quorum"},
-        )
-        self.channel.queue_bind(self.queue_name, self.queue_name, routing_key="")  # type: ignore[attr-defined]
+        self.channel = self.connection.channel()
+        self._declare_queue(self.channel, self.queue_name)
+
+        self.failure_connection = BlockingConnection(self.connection_parameters)
+        self.failure_channel = self.failure_connection.channel()
+        self._declare_queue(self.failure_channel, self.failure_queue_name)
 
     def _message_handler(self, msg: str) -> None:
         """
@@ -65,6 +78,47 @@ class QueueConsumer:
             self.message_callback(msg_obj)
         except json.JSONDecodeError as exception:
             logger.error("Error attempting to decode JSON: %s", str(exception))
+            raise
+        except Exception:
+            logger.exception("Problem processing message callback")
+            raise
+
+    def _publish_failure(self, body: bytes) -> None:
+        self.failure_channel.basic_publish(self.failure_queue_name, "", body)
+
+    def _process_ingress_message(self) -> None:
+        for header, _, body in self.channel.consume(
+            self.queue_name,
+            inactivity_timeout=5,
+        ):
+            try:
+                self._message_handler(body.decode())
+                self.channel.basic_ack(header.delivery_tag)
+            except AttributeError:
+                # If the message frame or body is missing attributes required e.g. the delivery tag
+                pass
+            except Exception:
+                logger.warning("Problem processing message: %s", body)
+                self._publish_failure(body)
+                self.channel.basic_ack(header.delivery_tag)
+            break
+
+    def _process_failure_message(self) -> None:
+        for header, _, body in self.failure_channel.consume(
+            self.failure_queue_name,
+            inactivity_timeout=5,
+        ):
+            try:
+                self._message_handler(body.decode())
+                self.failure_channel.basic_ack(header.delivery_tag)
+            except AttributeError:
+                # If the message frame or body is missing attributes required e.g. the delivery tag
+                pass
+            except Exception:
+                logger.warning("Problem processing failed message: %s", body)
+                self._publish_failure(body)
+                self.failure_channel.basic_ack(header.delivery_tag)
+            break
 
     def start_consuming(self, callback_func: Callable[[], None], run_once: bool = False) -> None:
         """
@@ -78,18 +132,7 @@ class QueueConsumer:
             if run_once:
                 run = False
             callback_func()
-            for header, _, body in self.channel.consume(  # type: ignore[attr-defined]
-                self.queue_name,
-                inactivity_timeout=5,
-            ):
-                try:
-                    self._message_handler(body.decode())
-                    self.channel.basic_ack(header.delivery_tag)  # type: ignore[attr-defined]
-                except AttributeError:
-                    # If the message frame or body is missing attributes required e.g. the delivery tag
-                    pass
-                except Exception:
-                    logger.warning("Problem processing message: %s", body)
-                break
+            self._process_ingress_message()
+            self._process_failure_message()
 
             time.sleep(0.1)

--- a/job_creator/test/test_main.py
+++ b/job_creator/test/test_main.py
@@ -1,0 +1,40 @@
+import importlib
+import sys
+from unittest import mock
+
+import pytest
+
+
+def import_main_module(monkeypatch):
+    monkeypatch.setenv("DEFAULT_RUNNER_SHA", "default-runner-sha")
+    monkeypatch.setenv("WATCHER_SHA", "watcher-sha")
+    with mock.patch("jobcreator.job_creator.JobCreator"):
+        if "jobcreator.main" in sys.modules:
+            return importlib.reload(sys.modules["jobcreator.main"])
+        return importlib.import_module("jobcreator.main")
+
+
+def test_process_message_unknown_job_type_raises(monkeypatch):
+    main_module = import_main_module(monkeypatch)
+
+    with pytest.raises(ValueError, match="message type not recognised"):
+        main_module.process_message({"job_type": "unexpected"})
+
+
+def test_main_passes_failure_queue_name_to_consumer(monkeypatch):
+    monkeypatch.setenv("INGRESS_QUEUE_NAME", "scheduled-jobs")
+    monkeypatch.setenv("FAILURE_QUEUE_NAME", "custom-failed-jobs")
+    main_module = import_main_module(monkeypatch)
+
+    with mock.patch.object(main_module, "QueueConsumer") as queue_consumer:
+        main_module.main()
+
+    queue_consumer.assert_called_once_with(
+        main_module.process_message,
+        queue_host="",
+        username="",
+        password="",
+        queue_name="scheduled-jobs",
+        failure_queue_name="custom-failed-jobs",
+    )
+    queue_consumer.return_value.start_consuming.assert_called_once_with(main_module.write_readiness_probe_file)

--- a/job_creator/test/test_queue_consumer.py
+++ b/job_creator/test/test_queue_consumer.py
@@ -1,3 +1,5 @@
+import json
+from types import SimpleNamespace
 from unittest import mock
 
 import pytest
@@ -5,105 +7,259 @@ from pika import PlainCredentials
 
 from jobcreator.queue_consumer import QueueConsumer
 
-MESSAGE_CALLBACK = mock.MagicMock()
-QUEUE_HOST = mock.MagicMock()
-USERNAME = mock.MagicMock()
+QUEUE_HOST = "queue-host"
+USERNAME = "username"
 PASSWORD = mock.MagicMock()
-QUEUE_NAME = mock.MagicMock()
+QUEUE_NAME = "scheduled-jobs"
+FAILURE_QUEUE_NAME = "failed-scheduled-jobs"
 
 
-@pytest.fixture(autouse=True, scope="module")
+@pytest.fixture
 def setup_queue_consumer():
+    message_callback = mock.MagicMock()
+    ingress_connection = mock.MagicMock()
+    ingress_channel = mock.MagicMock()
+    ingress_connection.channel.return_value = ingress_channel
+    failure_connection = mock.MagicMock()
+    failure_channel = mock.MagicMock()
+    failure_connection.channel.return_value = failure_channel
+
     with (
         mock.patch("jobcreator.queue_consumer.ConnectionParameters") as connection_parameters,
         mock.patch("jobcreator.queue_consumer.BlockingConnection") as blocking_connection,
     ):
-        quc = QueueConsumer(MESSAGE_CALLBACK, QUEUE_HOST, USERNAME, PASSWORD, QUEUE_NAME)
-        return quc, blocking_connection, connection_parameters
+        blocking_connection.side_effect = [ingress_connection, failure_connection]
+        queue_consumer = QueueConsumer(
+            message_callback,
+            QUEUE_HOST,
+            USERNAME,
+            PASSWORD,
+            QUEUE_NAME,
+            FAILURE_QUEUE_NAME,
+        )
+        yield SimpleNamespace(
+            queue_consumer=queue_consumer,
+            blocking_connection=blocking_connection,
+            connection_parameters=connection_parameters,
+            message_callback=message_callback,
+            ingress_connection=ingress_connection,
+            ingress_channel=ingress_channel,
+            failure_connection=failure_connection,
+            failure_channel=failure_channel,
+        )
+
+
+def reset_runtime_mocks(setup_queue_consumer):
+    setup_queue_consumer.message_callback.reset_mock()
+    setup_queue_consumer.ingress_channel.reset_mock()
+    setup_queue_consumer.failure_channel.reset_mock()
 
 
 def test_init_creates_credentials_and_connection_parameters(setup_queue_consumer):
-    quc, blocking_connection, connection_parameters = setup_queue_consumer
-    assert quc.message_callback == MESSAGE_CALLBACK
-    assert quc.queue_host == QUEUE_HOST
-    assert quc.queue_name == QUEUE_NAME
+    setup = setup_queue_consumer
+    queue_consumer = setup.queue_consumer
+
+    assert queue_consumer.message_callback == setup.message_callback
+    assert queue_consumer.queue_host == QUEUE_HOST
+    assert queue_consumer.queue_name == QUEUE_NAME
+    assert queue_consumer.failure_queue_name == FAILURE_QUEUE_NAME
 
     credentials = PlainCredentials(username=USERNAME, password=PASSWORD)
-    connection_parameters.assert_called_once_with(QUEUE_HOST, 5672, credentials=credentials)
-    assert connection_parameters.return_value == quc.connection_parameters
+    setup.connection_parameters.assert_called_once_with(QUEUE_HOST, 5672, credentials=credentials)
+    assert setup.connection_parameters.return_value == queue_consumer.connection_parameters
 
-    blocking_connection.assert_called_once_with(quc.connection_parameters)
-    assert blocking_connection.return_value == quc.connection
-    assert blocking_connection.return_value.channel.return_value == quc.channel
+    setup.blocking_connection.assert_has_calls(
+        [
+            mock.call(queue_consumer.connection_parameters),
+            mock.call(queue_consumer.connection_parameters),
+        ]
+    )
+    assert setup.ingress_connection == queue_consumer.connection
+    assert setup.ingress_channel == queue_consumer.channel
+    assert setup.failure_connection == queue_consumer.failure_connection
+    assert setup.failure_channel == queue_consumer.failure_channel
 
 
-def test_connect_to_broker(setup_queue_consumer):
-    quc, blocking_connection, _ = setup_queue_consumer
-    blocking_connection.assert_called_once_with(quc.connection_parameters)
-    assert blocking_connection.return_value == quc.connection
-    channel = blocking_connection.return_value.channel.return_value
-    assert channel == quc.channel
+def test_connect_to_broker_declares_ingress_and_failure_queues(setup_queue_consumer):
+    setup = setup_queue_consumer
 
-    channel.exchange_declare.assert_called_once_with(QUEUE_NAME, exchange_type="direct", durable=True)
-    channel.queue_declare.assert_called_once_with(QUEUE_NAME, durable=True, arguments={"x-queue-type": "quorum"})
-    channel.queue_bind.assert_called_once_with(QUEUE_NAME, QUEUE_NAME, routing_key="")
+    setup.ingress_channel.exchange_declare.assert_called_once_with(QUEUE_NAME, exchange_type="direct", durable=True)
+    setup.ingress_channel.queue_declare.assert_called_once_with(
+        QUEUE_NAME,
+        durable=True,
+        arguments={"x-queue-type": "quorum"},
+    )
+    setup.ingress_channel.queue_bind.assert_called_once_with(QUEUE_NAME, QUEUE_NAME, routing_key="")
+    setup.ingress_channel.basic_qos.assert_called_once_with(prefetch_count=1)
+
+    setup.failure_channel.exchange_declare.assert_called_once_with(
+        FAILURE_QUEUE_NAME,
+        exchange_type="direct",
+        durable=True,
+    )
+    setup.failure_channel.queue_declare.assert_called_once_with(
+        FAILURE_QUEUE_NAME,
+        durable=True,
+        arguments={"x-queue-type": "quorum"},
+    )
+    setup.failure_channel.queue_bind.assert_called_once_with(
+        FAILURE_QUEUE_NAME,
+        FAILURE_QUEUE_NAME,
+        routing_key="",
+    )
+    setup.failure_channel.basic_qos.assert_called_once_with(prefetch_count=1)
 
 
 def test_message_handler(setup_queue_consumer):
-    quc, _, _ = setup_queue_consumer
+    setup = setup_queue_consumer
     message = '{"help": "im stuck"}'
     msg_obj = {"help": "im stuck"}
-    MESSAGE_CALLBACK.reset_mock()
+    setup.message_callback.reset_mock()
 
     with mock.patch("jobcreator.queue_consumer.logger") as logger:
-        quc._message_handler(message)
+        setup.queue_consumer._message_handler(message)
 
     logger.info.assert_called_once_with("Message decoded as: %s", msg_obj)
-    MESSAGE_CALLBACK.assert_called_once_with(msg_obj)
+    setup.message_callback.assert_called_once_with(msg_obj)
 
 
-def test_message_handler_on_json_decode_error(setup_queue_consumer):
-    quc, _, _ = setup_queue_consumer
+def test_message_handler_on_json_decode_error_raises(setup_queue_consumer):
+    setup = setup_queue_consumer
     message = "{}::::::::://1//1/1!!!''''''"
-    MESSAGE_CALLBACK.reset_mock()
+    setup.message_callback.reset_mock()
 
-    with mock.patch("jobcreator.queue_consumer.logger") as logger:
-        quc._message_handler(message)
+    with mock.patch("jobcreator.queue_consumer.logger") as logger, pytest.raises(json.JSONDecodeError):
+        setup.queue_consumer._message_handler(message)
 
     logger.error.assert_called_once_with(
         "Error attempting to decode JSON: %s",
         "Extra data: line 1 column 3 (char 2)",
     )
-    MESSAGE_CALLBACK.assert_not_called()
+    setup.message_callback.assert_not_called()
 
 
-def test_start_consuming(setup_queue_consumer):
-    quc, _, _ = setup_queue_consumer
-    quc._message_handler = mock.MagicMock()
+def test_message_handler_callback_exception_raises_after_logging(setup_queue_consumer):
+    setup = setup_queue_consumer
+    setup.message_callback.side_effect = RuntimeError("callback failed")
+
+    with mock.patch("jobcreator.queue_consumer.logger") as logger, pytest.raises(RuntimeError, match="callback failed"):
+        setup.queue_consumer._message_handler('{"help": "im stuck"}')
+
+    logger.exception.assert_called_once_with("Problem processing message callback")
+
+
+def test_start_consuming_successful_ingress_acks_and_does_not_publish_failure(setup_queue_consumer):
+    setup = setup_queue_consumer
+    reset_runtime_mocks(setup)
     header = mock.MagicMock()
-    body = mock.MagicMock()
-    quc.channel.consume.return_value = [(header, mock.MagicMock(), body)]
+    header.delivery_tag = "ingress-tag"
+    body = b'{"help": "im stuck"}'
+    setup.ingress_channel.consume.return_value = [(header, None, body)]
+    setup.failure_channel.consume.return_value = []
     callback = mock.MagicMock()
 
-    quc.start_consuming(callback, run_once=True)
+    with mock.patch("jobcreator.queue_consumer.time.sleep"):
+        setup.queue_consumer.start_consuming(callback, run_once=True)
 
     callback.assert_called_once_with()
-    quc.channel.consume.assert_called_once_with(quc.queue_name, inactivity_timeout=5)
-    quc._message_handler.assert_called_once_with(body.decode.return_value)
-    quc.channel.basic_ack.assert_called_once_with(header.delivery_tag)
+    setup.message_callback.assert_called_once_with({"help": "im stuck"})
+    setup.ingress_channel.basic_ack.assert_called_once_with("ingress-tag")
+    setup.failure_channel.basic_publish.assert_not_called()
 
 
-def test_start_consumer_will_handle_exceptions_as_warnings(setup_queue_consumer):
-    quc, _, _ = setup_queue_consumer
+def test_start_consuming_malformed_json_publishes_failure_before_ack(setup_queue_consumer):
+    setup = setup_queue_consumer
+    reset_runtime_mocks(setup)
+    header = mock.MagicMock()
+    header.delivery_tag = "ingress-tag"
+    body = b"not-json"
+    setup.ingress_channel.consume.return_value = [(header, None, body)]
+    setup.failure_channel.consume.return_value = []
+    call_order = mock.Mock()
+    call_order.attach_mock(setup.failure_channel.basic_publish, "publish")
+    call_order.attach_mock(setup.ingress_channel.basic_ack, "ack")
 
-    def raise_exception():
-        raise Exception("The worst exception!")
+    with mock.patch("jobcreator.queue_consumer.time.sleep"):
+        setup.queue_consumer.start_consuming(mock.MagicMock(), run_once=True)
 
-    quc._message_handler = mock.MagicMock(side_effect=raise_exception)
-    body = mock.MagicMock()
-    quc.channel.consume.return_value = [(mock.MagicMock(), mock.MagicMock(), body)]
+    assert call_order.mock_calls == [
+        mock.call.publish(FAILURE_QUEUE_NAME, "", body),
+        mock.call.ack("ingress-tag"),
+    ]
 
-    with mock.patch("jobcreator.queue_consumer.logger") as logger:
-        quc.start_consuming(mock.MagicMock(), run_once=True)
 
-    logger.warning.assert_called_once_with("Problem processing message: %s", body)
+def test_start_consuming_callback_exception_publishes_failure_before_ack(setup_queue_consumer):
+    setup = setup_queue_consumer
+    reset_runtime_mocks(setup)
+    setup.message_callback.side_effect = RuntimeError("callback failed")
+    header = mock.MagicMock()
+    header.delivery_tag = "ingress-tag"
+    body = b'{"help": "im stuck"}'
+    setup.ingress_channel.consume.return_value = [(header, None, body)]
+    setup.failure_channel.consume.return_value = []
+    call_order = mock.Mock()
+    call_order.attach_mock(setup.failure_channel.basic_publish, "publish")
+    call_order.attach_mock(setup.ingress_channel.basic_ack, "ack")
+
+    with mock.patch("jobcreator.queue_consumer.time.sleep"):
+        setup.queue_consumer.start_consuming(mock.MagicMock(), run_once=True)
+
+    assert call_order.mock_calls == [
+        mock.call.publish(FAILURE_QUEUE_NAME, "", body),
+        mock.call.ack("ingress-tag"),
+    ]
+
+
+def test_start_consuming_failed_queue_success_acks_failed_message(setup_queue_consumer):
+    setup = setup_queue_consumer
+    reset_runtime_mocks(setup)
+    header = mock.MagicMock()
+    header.delivery_tag = "failed-tag"
+    body = b'{"help": "im stuck"}'
+    setup.ingress_channel.consume.return_value = []
+    setup.failure_channel.consume.return_value = [(header, None, body)]
+
+    with mock.patch("jobcreator.queue_consumer.time.sleep"):
+        setup.queue_consumer.start_consuming(mock.MagicMock(), run_once=True)
+
+    setup.message_callback.assert_called_once_with({"help": "im stuck"})
+    setup.failure_channel.basic_ack.assert_called_once_with("failed-tag")
+    setup.failure_channel.basic_publish.assert_not_called()
+
+
+def test_start_consuming_failed_queue_failure_republishes_before_ack(setup_queue_consumer):
+    setup = setup_queue_consumer
+    reset_runtime_mocks(setup)
+    setup.message_callback.side_effect = RuntimeError("callback failed")
+    header = mock.MagicMock()
+    header.delivery_tag = "failed-tag"
+    body = b'{"help": "im stuck"}'
+    setup.ingress_channel.consume.return_value = []
+    setup.failure_channel.consume.return_value = [(header, None, body)]
+    call_order = mock.Mock()
+    call_order.attach_mock(setup.failure_channel.basic_publish, "publish")
+    call_order.attach_mock(setup.failure_channel.basic_ack, "ack")
+
+    with mock.patch("jobcreator.queue_consumer.time.sleep"):
+        setup.queue_consumer.start_consuming(mock.MagicMock(), run_once=True)
+
+    assert call_order.mock_calls == [
+        mock.call.publish(FAILURE_QUEUE_NAME, "", body),
+        mock.call.ack("failed-tag"),
+    ]
+
+
+def test_start_consuming_publish_failure_does_not_ack_source_message(setup_queue_consumer):
+    setup = setup_queue_consumer
+    reset_runtime_mocks(setup)
+    setup.message_callback.side_effect = RuntimeError("callback failed")
+    setup.failure_channel.basic_publish.side_effect = RuntimeError("publish failed")
+    header = mock.MagicMock()
+    header.delivery_tag = "ingress-tag"
+    body = b'{"help": "im stuck"}'
+    setup.ingress_channel.consume.return_value = [(header, None, body)]
+
+    with pytest.raises(RuntimeError, match="publish failed"):
+        setup.queue_consumer.start_consuming(mock.MagicMock(), run_once=True)
+
+    setup.ingress_channel.basic_ack.assert_not_called()


### PR DESCRIPTION
Closes #423.

## Summary
- Add `FAILURE_QUEUE_NAME` support for jobcreator, defaulting to `failed-scheduled-jobs`.
- Route failed ingress messages to the failed queue before acking the original message.
- Retry messages from the failed queue and republish them on repeated failure.
- Make JSON decode errors, job processing failures, and unknown `job_type` values propagate into retry handling.
- Add tests for failed queue declaration, publish-before-ack behavior, retry handling, and main wiring.

## Testing
- `pytest job_creator/test -q`

## GitOps change
https://github.com/fiaisis/gitops/pull/296

